### PR TITLE
add option to force POST for long polling connections

### DIFF
--- a/main.c
+++ b/main.c
@@ -141,6 +141,7 @@ bool opt_debug = false;
 bool opt_protocol = false;
 bool want_longpoll = true;
 bool have_longpoll = false;
+bool lp_forcepost = false;
 bool use_syslog = false;
 static bool opt_quiet = false;
 static bool opt_loginput = false;
@@ -501,6 +502,11 @@ static struct opt_table opt_config_table[] = {
 	OPT_WITH_ARG("--device|-d",
 		     set_devices, NULL, &opt_device,
 	             "Select device to use, (Use repeat -d for multiple devices, default: all)"),
+#endif
+	OPT_WITHOUT_ARG("--lp-force-post",
+			opt_set_bool, &lp_forcepost,
+			"Force using HTTP POST method for long-polling connections"),
+#ifdef HAVE_OPENCL
 	OPT_WITH_ARG("--gpu-threads|-g",
 		     set_int_0_to_10, opt_show_intval, &opt_g_threads,
 		     "Number of threads per GPU (0 - 10)"),

--- a/miner.h
+++ b/miner.h
@@ -239,6 +239,7 @@ extern bool fulltest(const unsigned char *hash, const unsigned char *target);
 extern int opt_scantime;
 extern bool want_longpoll;
 extern bool have_longpoll;
+extern bool lp_forcepost;
 struct thread_q;
 
 struct work_restart {

--- a/util.c
+++ b/util.c
@@ -344,7 +344,15 @@ json_t *json_rpc_call(CURL *curl, const char *url,
 		curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
 	}
 	if (longpoll) {
-		curl_easy_setopt(curl, CURLOPT_HTTPGET, 1);
+		if (lp_forcepost) {
+			applog(LOG_DEBUG, "Using POST for long-polling connection.");
+			curl_easy_setopt(curl, CURLOPT_POST, 1);
+		}
+		else {
+			applog(LOG_DEBUG, "Using GET for long-polling connection.");
+			curl_easy_setopt(curl, CURLOPT_HTTPGET, 1);
+		}
+
 		curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, json_rpc_call_sockopt_cb);
 	} else {
 		curl_easy_setopt(curl, CURLOPT_POST, 1);


### PR DESCRIPTION
I noticed that deepbit long polling worked fine as long as cgminer used the POST method for LP connections, so I went ahead and tried it. Since it immediately started working again, I implemented a command line option to force using POST for LP connections.

It seems to work fine locally, but since I know less than 50% of the code and don't quite understand even that much, it'd be nice if you verified that I didn't forget something. I'm especially unsure about the whole option parsing part, specifically how this would look in a JSON config file.
