### PR TITLE
Use pkg-config to check for libcurl version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,8 +124,10 @@ AM_CONDITIONAL([HAS_YASM], [test x$has_yasm = xtrue])
 
 PKG_PROG_PKG_CONFIG()
 
-LIBCURL_CHECK_CONFIG(, 7.10.1, ,  [AC_MSG_ERROR([Missing required libcurl dev >= 7.10.1])])
-LIBCURL_CHECK_CONFIG(, 7.15.6, [AC_DEFINE([CURL_HAS_SOCKOPT], [1], [Defined if version of curl supports sockopts.])],)
+PKG_CHECK_MODULES([LIBCURL], [libcurl >= 7.15.6], [AC_DEFINE([CURL_HAS_SOCKOPT], [1], [Defined if version of curl supports sockopts.])],
+[PKG_CHECK_MODULES([LIBCURL], [libcurl >= 7.10.1], ,[AC_MSG_ERROR([Missing required libcurl dev >= 7.10.1])])])
+AC_SUBST(LIBCURL_CPPFLAGS)
+AC_SUBST(LIBCURL_LIBS)
 
 dnl CCAN wants to know a lot of vars.
 # All the configuration checks.  Regrettably, the __attribute__ checks will


### PR DESCRIPTION
Fixes autogen on OSX Lion, might fix for other platforms which
don't ship those libcurl m4 macros.
