### PR TITLE
Add new option: --monitor <cmd>

### DIFF
--- a/main.c
+++ b/main.c
@@ -693,6 +693,7 @@ static char *load_config(const char *arg, void *unused)
 static char *print_ndevs_and_exit(int *ndevs)
 {
 	printf("%i GPU devices detected\n", *ndevs);
+	fflush(stdout);
 	exit(*ndevs);
 }
 #endif


### PR DESCRIPTION
```
Option lets user specify a command <cmd> that will get
forked by cgminer on startup. cgminer's stderr output
subsequently gets piped directly to this command.

This permits smart batch monitoring of the miner by a
baby-sitter log parser while retaining the full benefit
of the curses interface, e.g. when running cgminer under
screen.

Doing the same thing is possible using advanced bash
redirection paraphernalia, but it is somewhat of a pain,
especially when running screen'd.

This option makes things more straightforward.
```
