### PR TITLE
Patch to re-enable target checking of solutions

### DIFF
--- a/util.c
+++ b/util.c
@@ -561,7 +561,7 @@ bool fulltest(const unsigned char *hash, const unsigned char *target)
 		free(target_str);
 	}
 
-	return true;	/* FIXME: return rc; */
+	return rc;
 }
 
 struct thread_q *tq_new(void)


### PR DESCRIPTION
Currently, all solutions that match H==0 are submitted, regardless of whether they match the target supplied in the getwork response.

This patch re-enables the check against the target, which was disabled by jgarzik in commit b2372e70f0dc270877e2, because it didn't work on some platforms(?). I wasn't able to find out which platforms this refers to, but it seems to work on x86 and x86_64.

This is increasingly important as the total hash rate of bitcoin increases and pools begin to think of increasing the difficulty for shares.
