### PR TITLE
Bugfix: Don't ignore nonces beginning with FF

### DIFF
--- a/findnonce.c
+++ b/findnonce.c
@@ -175,15 +175,15 @@ static void *postcalc_hash(void *userdata)
 
 	pthread_detach(pthread_self());
 cycle:
-	while (entry < FOUND) {
+	while (1) {
+		if (entry == FOUND)
+			goto out;
 		if (pcd->res[entry]) {
 			nonce = pcd->res[entry++];
 			break;
 		}
 		entry++;
 	}
-	if (entry == FOUND)
-		goto out;
 
 	A = blk->cty_a; B = blk->cty_b;
 	C = blk->cty_c; D = blk->cty_d;


### PR DESCRIPTION
Since the check for end-of-nonces was taking place after incrementing beyond the current nonce, yet before that nonce had been submitted, nonces starting with FF (due to the phatk nonce output format) were ignored. Therefore, I have moved the check inside the while loop, before the increment occurs.
