### PR TITLE
BitForce Windows support

### DIFF
--- a/miner.h
+++ b/miner.h
@@ -255,6 +255,7 @@ struct cgpu_info {
 	int device_id;
 	char *device_path;
 	FILE *device_file;
+	int device_fd;
 
 	bool enabled;
 	int accepted;


### PR DESCRIPTION
Need to use CreateFile and low-level (descriptor-based) C APIs on Windows, since fopen doesn't work with serial ports.

This is tested on Windows 7 Professional (64-bit). I built the 32-bit EXE on Linux with MingW.
