### PR TITLE
Series of fixes around longpolling

### DIFF
--- a/util.c
+++ b/util.c
@@ -373,6 +373,8 @@ json_t *json_rpc_call(CURL *curl, const char *url,
 	headers = curl_slist_append(headers,
 		"Content-type: application/json");
 	headers = curl_slist_append(headers,
+		longpoll ?
+		"X-Mining-Extensions: longpoll midstate rollntime submitold" :
 		"X-Mining-Extensions: longpoll midstate rollntime");
 	headers = curl_slist_append(headers, len_hdr);
 	headers = curl_slist_append(headers, user_agent_hdr);


### PR DESCRIPTION
1. Bugfix: Only discard work from other pools, if the block really has changed
   The longpoll fix which triggered new work even if the block hadn't changed was too aggressive, and discarded work from other pools as well. This is fixed by making the "current block" counter pool-specific, and tracking the real block again.
2. Advertise longpoll support in X-Mining-Extensions
3. Support for submitold extension to longpoll
   This extension allows pools to longpoll for reasons other than a new Bitcoin block (such as transaction fees, merged mining, etc) without discarding shares from the last work. See https://en.bitcoin.it/wiki/Getwork#submitold for specification
