### PR TITLE
Bugfix: Need to open BitForce tty for read-write

### DIFF
--- a/bitforce.c
+++ b/bitforce.c
@@ -41,7 +41,7 @@ static int BFopen(const char *devpath)
 
 static int BFopen(const char *devpath)
 {
-	return open(devpath, O_CLOEXEC | O_NOCTTY);
+	return open(devpath, O_RDWR | O_CLOEXEC | O_NOCTTY);
 }
 
 #endif


### PR DESCRIPTION
This got broken when I added Windows support. :(
