### PR TITLE
fix strcpy NULL pointer if env HOME unset.

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -929,9 +929,10 @@ static void load_default_config(void)
 	char buf[PATH_MAX];
 
 #if defined(unix)
-	strcpy(buf, getenv("HOME"));
-	if (*buf)
+	if (getenv("HOME") && *getenv("HOME")) {
+	        strcpy(buf, getenv("HOME"));
 		strcat(buf, "/");
+	}
 	else
 		strcpy(buf, "");
 	strcat(buf, ".cgminer/");
@@ -2640,9 +2641,10 @@ retry:
 		char *str, filename[PATH_MAX], prompt[PATH_MAX + 50];
 
 #if defined(unix)
-		strcpy(filename, getenv("HOME"));
-		if (*filename)
+		if (getenv("HOME") && *getenv("HOME")) {
+		        strcpy(filename, getenv("HOME"));
 			strcat(filename, "/");
+		}
 		else
 			strcpy(filename, "");
 		strcat(filename, ".cgminer/");


### PR DESCRIPTION
if env HOME unset(not empty), getenv("HOME") return NULL pointer and then causes strcpy error.
