### PR TITLE
Bugfix: Always wait at least 1 second between requests, even if scantime is lower than thread count

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -3122,7 +3122,7 @@ static bool queue_request(struct thr_info *thr, bool needed)
 	/* Space out retrieval of extra work according to the number of mining
 	 * threads */
 	if (rq >= mining_threads + staged_extras &&
-	    (now.tv_sec - requested_tv_sec) < opt_scantime / (mining_threads + 1))
+	    (now.tv_sec - requested_tv_sec) < (opt_scantime / (mining_threads + 1) ?: 1))
 		return true;
 
 	/* fill out work request message */


### PR DESCRIPTION
Without this, CGMiner will try to spawn hundreds to thousands of threads regularly if scantime is < mining threads.

To reproduce with a single GPU, use -s 1 -g 2
