### PR TITLE
Add check for CPU affinity ability

### DIFF
--- a/device-cpu.c
+++ b/device-cpu.c
@@ -39,7 +39,7 @@
 	#include <fcntl.h>
 #endif
 
-#ifdef __linux /* Linux specific policy and affinity management */
+#if defined(__linux) && defined(cpu_set_t) /* Linux specific policy and affinity management */
 #include <sched.h>
 static inline void drop_policy(void)
 {


### PR DESCRIPTION
A check for '__linux' isn't enough for some arch's. This adds an additional check for 'cpu_set_t' to make sure Linux environments without the ability to set processor affinity, can still compile.
