### PR TITLE
Fixing leak in resp_hdr_cb

### DIFF
--- a/util.c
+++ b/util.c
@@ -30,11 +30,6 @@
 # include <winsock2.h>
 # include <mstcpip.h>
 #endif
-#ifdef DMALLOC
-#include <stdlib.h>
-#include <string.h>
-#include <dmalloc.h>
-#endif
 
 #include "miner.h"
 #include "elist.h"


### PR DESCRIPTION
Memory is allocated for key and val, and longpoll address, when found, is stored in the header_info and prevented from being freed there. This pointer is stored during pool probing but once that's done it was just being lost.

Not so visible but also leaking was the refuse reason string.
