### PR TITLE
Bugfix: Cut Icarus blocking time on Windows down to 1 decisecond, to match current timeout

### DIFF
--- a/driver-icarus.c
+++ b/driver-icarus.c
@@ -107,7 +107,8 @@ static int icarus_open(const char *devpath)
 	if (unlikely(hSerial == INVALID_HANDLE_VALUE))
 		return -1;
 
-	COMMTIMEOUTS cto = {1000, 0, 1000, 0, 1000};
+	const DWORD ctoms = ICARUS_READ_FAULT_DECISECONDS * 100;
+	COMMTIMEOUTS cto = {ctoms, 0, ctoms, 0, ctoms};
 	SetCommTimeouts(hSerial, &cto);
 
 	return _open_osfhandle((LONG)hSerial, 0);


### PR DESCRIPTION
The timeout was reduced to 0.1 seconds to check for work_restart, but I missed the Windows timeout adjustment
