### PR TITLE
configure.ac epoll.h not used now

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,6 @@ gl_INIT
 dnl Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS(syslog.h)
-AC_CHECK_HEADERS([sys/epoll.h])
 
 AC_FUNC_ALLOCA
 


### PR DESCRIPTION
Not used since icarus.c overwrite
Can be put back later if needed
