### PR TITLE
Keep device/driver API clean by abstracting performance stats data request

### DIFF
--- a/miner.h
+++ b/miner.h
@@ -207,7 +207,7 @@ struct device_api {
 	void (*reinit_device)(struct cgpu_info*);
 	void (*get_statline_before)(char*, struct cgpu_info*);
 	void (*get_statline)(char*, struct cgpu_info*);
-	void (*get_api_stats)(char*, struct cgpu_info*, bool);
+	json_t* (*get_extra_device_perf_stats)(struct cgpu_info*);
 
 	// Thread-specific functions
 	bool (*thread_prepare)(struct thr_info*);


### PR DESCRIPTION
Replace newly-added Kano's-JSON-API-specific get_api_stats driver API with a sane get_extra_device_perf_stats that returns a Jansson JSON Object with key/value pairs of data, and let the JSON API display that how it likes.

Also, I request review of any future changes made to the device API before merging...
