### PR TITLE
FPGA - allow device detect override without an open failure

### DIFF
--- a/README
+++ b/README
@@ -198,6 +198,8 @@ FPGA mining boards(BitForce, Icarus, Ztex) only options:
 
 --scan-serial|-S <arg> Serial port to probe for FPGA mining device
 
+     This option is only for Icarus and/or BitForce FPGA's
+
      By default, cgminer will scan for autodetected FPGAs unless at least one
      -S is specified for that driver. If you specify -S and still want cgminer
      to scan, you must also use "-S auto". If you want to prevent cgminer from
@@ -208,6 +210,10 @@ FPGA mining boards(BitForce, Icarus, Ztex) only options:
      On linux <arg> is usually of the format /dev/ttyUSBn
      On windows <arg> is usually of the format \\.\COMn
        (where n = the correct device number for the FPGA device)
+
+     The official supplied binaries are compiled with support for both Icarus and Bitforce
+     To force the code to only attempt one type of detection on a device add "ica:" or "bfl:"
+     to the front of the device specification e.g. -S ica:/dev/ttyUSB0 -S bfl:/dev/ttyUSB1
 
 For other FPGA details see the FPGA-README
 

--- a/driver-bitforce.c
+++ b/driver-bitforce.c
@@ -101,9 +101,11 @@ static bool bitforce_detect_one(const char *devpath)
 	if (total_devices == MAX_DEVICES)
 		return false;
 
+	applog(LOG_DEBUG, "BitForce Detect: Attempting to open %s", devpath);
+
 	int fdDev = BFopen(devpath);
 	if (unlikely(fdDev == -1)) {
-		applog(LOG_DEBUG, "BitForce Detect: Failed to open %s", devpath);
+		applog(LOG_ERR, "BitForce Detect: Failed to open %s", devpath);
 		return false;
 	}
 	BFwrite(fdDev, "ZGX", 3);
@@ -216,8 +218,11 @@ static void bitforce_detect()
 
 	list_for_each_entry_safe(iter, tmp, &scan_devices, list) {
 		s = iter->string;
-		if (!strncmp("bitforce:", iter->string, 9))
-			s += 9;
+		if (s[SCANSERIAL_ID_LENGTH] == ':') {
+			if (strncasecmp(s, SCANSERIAL_ID_BFL, SCANSERIAL_ID_LENGTH))
+				continue;
+			s += (SCANSERIAL_ID_LENGTH + 1);
+		}
 		if (!strcmp(s, "auto"))
 			autoscan = true;
 		else

--- a/driver-icarus.c
+++ b/driver-icarus.c
@@ -438,6 +438,8 @@ static bool icarus_detect_one(const char *devpath)
 	if (total_devices == MAX_DEVICES)
 		return false;
 
+	applog(LOG_DEBUG, "Icarus Detect: Attempting to open %s", devpath);
+
 	fd = icarus_open(devpath);
 	if (unlikely(fd == -1)) {
 		applog(LOG_ERR, "Icarus Detect: Failed to open %s", devpath);
@@ -508,8 +510,11 @@ static void icarus_detect()
 
 	list_for_each_entry_safe(iter, tmp, &scan_devices, list) {
 		s = iter->string;
-		if (!strncmp("icarus:", iter->string, 7))
-			s += 7;
+		if (s[SCANSERIAL_ID_LENGTH] == ':') {
+			if (strncasecmp(s, SCANSERIAL_ID_ICA, SCANSERIAL_ID_LENGTH))
+				continue;
+			s += (SCANSERIAL_ID_LENGTH + 1);
+		}
 		if (!strcmp(s, "auto") || !strcmp(s, "noauto"))
 			continue;
 		if (icarus_detect_one(s))

--- a/miner.h
+++ b/miner.h
@@ -577,6 +577,12 @@ extern int add_pool_details(bool live, char *url, char *user, char *pass);
 #define MAX_INTENSITY 14
 #define _MAX_INTENSITY_STR "14"
 
+#if defined(USE_BITFORCE) || defined(USE_ICARUS)
+#define SCANSERIAL_ID_LENGTH 3
+#define SCANSERIAL_ID_ICA "ICA"
+#define SCANSERIAL_ID_BFL "BFL"
+#endif
+
 extern struct list_head scan_devices;
 extern int nDevs;
 extern int opt_n_threads;


### PR DESCRIPTION
Original code works by failing to open an invalid devpath
New version doesn't attempt to open the invalid devpath
Also added the documentation (that wasn't there before)
On certain versions of windows the failure reduces the number of USB ports that can be opened by a single cgminer
Anyone using the old undocumented feature will need to change from using
 icarus:/dev/ttyUSB0 to ica:/dev/ttyUSB0
 bitforce:/dev/ttyUSB0 to bfl:/dev/ttyUSB0
as per the new documentation
