### PR TITLE
FPGA - allow device detect override without an open failure

### DIFF
--- a/README
+++ b/README
@@ -198,6 +198,8 @@ FPGA mining boards(BitForce, Icarus, Ztex) only options:
 
 --scan-serial|-S <arg> Serial port to probe for FPGA mining device
 
+     This option is only for Icarus and/or BitForce FPGA's
+
      By default, cgminer will scan for autodetected FPGAs unless at least one
      -S is specified for that driver. If you specify -S and still want cgminer
      to scan, you must also use "-S auto". If you want to prevent cgminer from
@@ -208,6 +210,11 @@ FPGA mining boards(BitForce, Icarus, Ztex) only options:
      On linux <arg> is usually of the format /dev/ttyUSBn
      On windows <arg> is usually of the format \\.\COMn
        (where n = the correct device number for the FPGA device)
+
+     The official supplied binaries are compiled with support for both Icarus
+     and Bitforce. To force the code to only attempt detection with a specific
+     driver, prepend the argument with the driver name followed by a colon.
+     For example, "icarus:/dev/ttyUSB0" or "bitforce:\\.\COM5"
 
 For other FPGA details see the FPGA-README
 

--- a/driver-icarus.c
+++ b/driver-icarus.c
@@ -438,6 +438,8 @@ static bool icarus_detect_one(const char *devpath)
 	if (total_devices == MAX_DEVICES)
 		return false;
 
+	applog(LOG_DEBUG, "Icarus Detect: Attempting to open %s", devpath);
+
 	fd = icarus_open(devpath);
 	if (unlikely(fd == -1)) {
 		applog(LOG_ERR, "Icarus Detect: Failed to open %s", devpath);
@@ -504,12 +506,15 @@ static bool icarus_detect_one(const char *devpath)
 static void icarus_detect()
 {
 	struct string_elist *iter, *tmp;
-	const char*s;
+	const char*s, *p;
 
 	list_for_each_entry_safe(iter, tmp, &scan_devices, list) {
 		s = iter->string;
-		if (!strncmp("icarus:", iter->string, 7))
-			s += 7;
+		if ((p = strchr(s, ':')) && p[1] != '\0') {
+			if (strncasecmp(s, icarus_api.dname, p - s))
+				continue;
+			s = p + 1;
+		}
 		if (!strcmp(s, "auto") || !strcmp(s, "noauto"))
 			continue;
 		if (icarus_detect_one(s))


### PR DESCRIPTION
This is #215, but with the fixes I suggested so it's compatible with older cgminer.

So this does change:
- Document driver-specific probing in README
- Skip harmless probing of invalid serial port paths with foreign driver names

It doesn't change:
- Any actual behaviour
- Any user configuration files/commands
