### PR TITLE
FPGA - allow device detect override without an open failure

### DIFF
--- a/README
+++ b/README
@@ -198,6 +198,8 @@ FPGA mining boards(BitForce, Icarus, Ztex) only options:
 
 --scan-serial|-S <arg> Serial port to probe for FPGA mining device
 
+     This option is only for BitForce, Icarus, and/or ModMiner FPGAs
+
      By default, cgminer will scan for autodetected FPGAs unless at least one
      -S is specified for that driver. If you specify -S and still want cgminer
      to scan, you must also use "-S auto". If you want to prevent cgminer from
@@ -208,6 +210,11 @@ FPGA mining boards(BitForce, Icarus, Ztex) only options:
      On linux <arg> is usually of the format /dev/ttyUSBn
      On windows <arg> is usually of the format \\.\COMn
        (where n = the correct device number for the FPGA device)
+
+     The official supplied binaries are compiled with support for all FPGAs.
+     To force the code to only attempt detection with a specific driver,
+     prepend the argument with the driver name followed by a colon.
+     For example, "icarus:/dev/ttyUSB0" or "bitforce:\\.\COM5"
 
 For other FPGA details see the FPGA-README
 

--- a/driver-bitforce.c
+++ b/driver-bitforce.c
@@ -53,9 +53,11 @@ static bool bitforce_detect_one(const char *devpath)
 	char *s;
 	char pdevbuf[0x100];
 
+	applog(LOG_DEBUG, "BitForce Detect: Attempting to open %s", devpath);
+
 	int fdDev = BFopen(devpath);
 	if (unlikely(fdDev == -1)) {
-		applog(LOG_DEBUG, "BitForce Detect: Failed to open %s", devpath);
+		applog(LOG_ERR, "BitForce Detect: Failed to open %s", devpath);
 		return false;
 	}
 	BFwrite(fdDev, "ZGX", 3);
@@ -96,7 +98,7 @@ static char bitforce_detect_auto()
 
 static void bitforce_detect()
 {
-	serial_detect_auto("bitforce", bitforce_detect_one, bitforce_detect_auto);
+	serial_detect_auto(bitforce_api.dname, bitforce_detect_one, bitforce_detect_auto);
 }
 
 static void get_bitforce_statline_before(char *buf, struct cgpu_info *bitforce)

--- a/driver-icarus.c
+++ b/driver-icarus.c
@@ -379,6 +379,8 @@ static bool icarus_detect_one(const char *devpath)
 	unsigned char ob_bin[64], nonce_bin[ICARUS_READ_SIZE];
 	char *nonce_hex;
 
+	applog(LOG_DEBUG, "Icarus Detect: Attempting to open %s", devpath);
+
 	fd = icarus_open2(devpath, true);
 	if (unlikely(fd == -1)) {
 		applog(LOG_ERR, "Icarus Detect: Failed to open %s", devpath);
@@ -444,7 +446,7 @@ static bool icarus_detect_one(const char *devpath)
 
 static void icarus_detect()
 {
-	serial_detect("icarus", icarus_detect_one);
+	serial_detect(icarus_api.dname, icarus_detect_one);
 }
 
 static bool icarus_prepare(struct thr_info *thr)

--- a/driver-modminer.c
+++ b/driver-modminer.c
@@ -103,7 +103,7 @@ modminer_detect_auto()
 static void
 modminer_detect()
 {
-	serial_detect_auto("modminer", modminer_detect_one, modminer_detect_auto);
+	serial_detect_auto(modminer_api.dname, modminer_detect_one, modminer_detect_auto);
 }
 
 static void

--- a/fpgautils.c
+++ b/fpgautils.c
@@ -115,21 +115,26 @@ serial_autodetect_devserial(detectone_func_t detectone, const char*prodname)
 }
 
 char
-_serial_detect(const char*dnamec, size_t dnamel, detectone_func_t detectone, autoscan_func_t autoscan, bool force_autoscan)
+_serial_detect(const char*dname, detectone_func_t detectone, autoscan_func_t autoscan, bool force_autoscan)
 {
 	if (total_devices == MAX_DEVICES)
 		return 0;
 
 	struct string_elist *iter, *tmp;
-	const char*s;
+	const char*s, *p;
 	bool inhibitauto = false;
 	bool forceauto = false;
 	char found = 0;
+	size_t dnamel = strlen(dname);
 
 	list_for_each_entry_safe(iter, tmp, &scan_devices, list) {
 		s = iter->string;
-		if (!strncmp(dnamec, iter->string, dnamel))
-			s += dnamel;
+		if ((p = strchr(s, ':')) && p[1] != '\0') {
+			size_t plen = p - s;
+			if (plen != dnamel || strncasecmp(s, dname, plen))
+				continue;
+			s = p + 1;
+		}
 		if (!strcmp(s, "auto"))
 			forceauto = true;
 		else

--- a/fpgautils.h
+++ b/fpgautils.h
@@ -16,13 +16,13 @@
 typedef bool(*detectone_func_t)(const char*);
 typedef char(*autoscan_func_t)();
 
-extern char _serial_detect(const char*dnamec, size_t dnamel, detectone_func_t, autoscan_func_t, bool force_autoscan);
+extern char _serial_detect(const char*dname, detectone_func_t, autoscan_func_t, bool force_autoscan);
 #define serial_detect_fauto(dname, detectone, autoscan)  \
-	_serial_detect(dname ":", sizeof(dname)+1, detectone, autoscan, true)
+	_serial_detect(dname, detectone, autoscan, true)
 #define serial_detect_auto(dname, detectone, autoscan)  \
-	_serial_detect(dname ":", sizeof(dname)+1, detectone, autoscan, false)
+	_serial_detect(dname, detectone, autoscan, false)
 #define serial_detect(dname, detectone)  \
-	_serial_detect(dname ":", sizeof(dname)+1, detectone,     NULL, false)
+	_serial_detect(dname, detectone,     NULL, false)
 extern char serial_autodetect_devserial(detectone_func_t, const char*prodname);
 extern char serial_autodetect_udev     (detectone_func_t, const char*prodname);
 


### PR DESCRIPTION
Also fixes a bug in the fpgautils refactor (for some reason "icarus:" prefix didn't work)
