### PR TITLE
modminer: Don't delay 2nd+ FPGAs during work restart

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -3824,6 +3824,8 @@ void *miner_thread(void *userdata)
 	const time_t request_interval = opt_scantime * 2 / 3 ? : 1;
 	unsigned const long request_nonce = MAXTHREADS / 3 * 2;
 	bool requested = false;
+	const bool primary = (!mythr->device_thread) || mythr->primary_thread;
+
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 
 	gettimeofday(&getwork_start, NULL);
@@ -3905,7 +3907,7 @@ void *miner_thread(void *userdata)
 				 * starting of every next thread to try and get
 				 * all devices busy before worrying about
 				 * getting work for their extra threads */
-				if (mythr->device_thread) {
+				if (!primary) {
 					struct timespec rgtp;
 
 					rgtp.tv_sec = 0;

--- a/driver-modminer.c
+++ b/driver-modminer.c
@@ -318,6 +318,8 @@ modminer_fpga_init(struct thr_info *thr)
 
 	mutex_unlock(&modminer->device_mutex);
 
+	thr->primary_thread = true;
+
 	return true;
 }
 

--- a/miner.h
+++ b/miner.h
@@ -391,6 +391,7 @@ struct thread_q {
 struct thr_info {
 	int		id;
 	int		device_thread;
+	bool		primary_thread;
 
 	pthread_t	pth;
 	struct thread_q	*q;


### PR DESCRIPTION
Add primary_thread boolean to threads to identify a single one as the "primary" thread for shared-resource multithreading.
This is needed since ModMiners use multiple threads to interface with independent hashing components.
