### PR TITLE
Bugfix: Don't declare devices SICK if they're just busy initializing

### DIFF
--- a/api.c
+++ b/api.c
@@ -170,6 +170,7 @@ static const char *APIVERSION = "1.14";
 static const char *DEAD = "Dead";
 static const char *SICK = "Sick";
 static const char *NOSTART = "NoStart";
+static const char *INIT = "Initializing";
 static const char *DISABLED = "Disabled";
 static const char *ALIVE = "Alive";
 static const char *REJECTING = "Rejecting";
@@ -1262,6 +1263,8 @@ static void gpustatus(int gpu, bool isjson)
 			status = (char *)SICK;
 		else if (cgpu->status == LIFE_NOSTART)
 			status = (char *)NOSTART;
+		else if (cgpu->status == LIFE_INIT)
+			status = (char *)INIT;
 		else
 			status = (char *)ALIVE;
 
@@ -1361,6 +1364,8 @@ static void pgastatus(int pga, bool isjson)
 			status = (char *)SICK;
 		else if (cgpu->status == LIFE_NOSTART)
 			status = (char *)NOSTART;
+		else if (cgpu->status == LIFE_INIT)
+			status = (char *)INIT;
 		else
 			status = (char *)ALIVE;
 

--- a/cgminer.c
+++ b/cgminer.c
@@ -4594,6 +4594,7 @@ static void *watchdog_thread(void __maybe_unused *userdata)
 			dev_count_dead = (cgpu->low_count > WATCHDOG_DEAD_COUNT);
 
 			if (cgpu->status != LIFE_WELL && (now.tv_sec - thr->last.tv_sec < WATCHDOG_SICK_TIME) && dev_count_well) {
+				if (cgpu->status != LIFE_INIT)
 				applog(LOG_ERR, "%s: Recovered, declaring WELL!", dev_str);
 				cgpu->status = LIFE_WELL;
 				cgpu->device_last_well = time(NULL);
@@ -5440,6 +5441,7 @@ begin_bench:
 		struct cgpu_info *cgpu = devices[i];
 		cgpu->thr = malloc(sizeof(*cgpu->thr) * (cgpu->threads+1));
 		cgpu->thr[cgpu->threads] = NULL;
+		cgpu->status = LIFE_INIT;
 
 		for (j = 0; j < cgpu->threads; ++j, ++k) {
 			thr = &thr_info[k];

--- a/driver-opencl.c
+++ b/driver-opencl.c
@@ -639,6 +639,7 @@ retry:
 				case LIFE_DEAD:
 					wlog("DEAD reported in %s", checkin);
 					break;
+				case LIFE_INIT:
 				case LIFE_NOSTART:
 					wlog("Never started");
 					break;

--- a/miner.h
+++ b/miner.h
@@ -163,7 +163,8 @@ enum alive {
 	LIFE_WELL,
 	LIFE_SICK,
 	LIFE_DEAD,
-	LIFE_NOSTART
+	LIFE_NOSTART,
+	LIFE_INIT,
 };
 
 


### PR DESCRIPTION
This mainly applies to ModMiner since it takes 4-5 minutes to upload the bitstream
