### PR TITLE
Bugfix: Copy argv[0] given to dirname()

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -4105,6 +4105,7 @@ int main (int argc, char *argv[])
 	bool pools_active = false;
 	struct sigaction handler;
 	struct thr_info *thr;
+	char *s;
 	unsigned int k;
 	int i, j;
 
@@ -4135,7 +4136,9 @@ int main (int argc, char *argv[])
 	opt_kernel_path = alloca(PATH_MAX);
 	strcpy(opt_kernel_path, CGMINER_PREFIX);
 	cgminer_path = alloca(PATH_MAX);
-	strcpy(cgminer_path, dirname(argv[0]));
+	s = strdup(argv[0]);
+	strcpy(cgminer_path, dirname(s));
+	free(s);
 	strcat(cgminer_path, "/");
 #ifdef WANT_CPUMINE
 	// Hack to make cgminer silent when called recursively on WIN32


### PR DESCRIPTION
Per manpage, dirname can (and does on GNU/Linux!) modify its argument
