### PR TITLE
Add scrypt support while writing conf

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -2911,6 +2911,20 @@ void write_config(FILE *fcfg)
 					break;
 			}
 		}
+#ifdef USE_SCRYPT
+		fputs("\",\n\"lookup-gap\" : \"", fcfg);
+		for(i = 0; i < nDevs; i++)
+			fprintf(fcfg, "%s%d", i > 0 ? "," : "",
+				(int)gpus[i].lookup_gap);
+		fputs("\",\n\"thread-concurrency\" : \"", fcfg);
+		for(i = 0; i < nDevs; i++)
+			fprintf(fcfg, "%s%d", i > 0 ? "," : "",
+				(int)gpus[i].thread_concurrency);
+		fputs("\",\n\"shaders\" : \"", fcfg);
+		for(i = 0; i < nDevs; i++)
+			fprintf(fcfg, "%s%d", i > 0 ? "," : "",
+				(int)gpus[i].shaders);
+#endif
 #ifdef HAVE_ADL
 		fputs("\",\n\"gpu-engine\" : \"", fcfg);
 		for(i = 0; i < nDevs; i++)


### PR DESCRIPTION
I saw the scrypt related configs(lookup-gap, thread-concurrency, shaders) won't be saved into config file, so I write this patch for it.
