### PR TITLE
Comm error bug fix

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -92,7 +92,7 @@ static bool opt_realquiet;
 bool opt_loginput;
 const int opt_cutofftemp = 95;
 static int opt_retries = -1;
-static int opt_fail_pause = 5;
+int opt_fail_pause = 5;
 static int fail_pause = 5;
 int opt_log_interval = 5;
 static int opt_queue = 1;

--- a/driver-bitforce.c
+++ b/driver-bitforce.c
@@ -480,6 +480,7 @@ static int64_t bitforce_scanhash(struct thr_info *thr, struct work *work, int64_
 	if (!bitforce_send_work(thr, work)) {
 		if (thr->work_restart)
 			return 0;
+		sleep(opt_fail_pause);
 		goto commerr;
 	}
 

--- a/miner.h
+++ b/miner.h
@@ -657,6 +657,7 @@ extern int total_getworks, total_stale, total_discarded;
 extern unsigned int local_work;
 extern unsigned int total_go, total_ro;
 extern const int opt_cutofftemp;
+extern int opt_fail_pause;
 extern int opt_log_interval;
 extern unsigned long long global_hashrate;
 


### PR DESCRIPTION
This will log comm errors (and clear the receive buffer) for errors occurring in send_work 

Same as #280, but doesn't break longpoll-during-send_work.
