### PR TITLE
Bugfix: Initialize temporary stratum work

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -4150,6 +4150,7 @@ static void *stratum_thread(void *userdata)
 		free(s);
 		if (pool->swork.clean) {
 			struct work work;
+			memset(&work, 0, sizeof(work));
 
 			/* Generate a single work item to update the current
 			 * block database */


### PR DESCRIPTION
Without this, work.mandatory was undefined and might have been true, skipping block change handling code
When this happens, it causes newfound shares to be considered stale always.
