### PR TITLE
Changes to build prototypes to support building on FreeBSD 9.1-RC2 amd64

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ cgminer_LDADD	= $(DLOPEN_FLAGS) @LIBCURL_LIBS@ @JANSSON_LIBS@ @PTHREAD_LIBS@ \
 		  @OPENCL_LIBS@ @NCURSES_LIBS@ @PDCURSES_LIBS@ @WS2_LIBS@ \
 		  @UDEV_LIBS@ @USB_LIBS@ \
 		  @MATH_LIBS@ lib/libgnu.a ccan/libccan.a
-cgminer_CPPFLAGS = -I$(top_builddir)/lib -I$(top_srcdir)/lib @OPENCL_FLAGS@
+cgminer_CPPFLAGS = -I$(top_builddir)/lib -I$(top_srcdir)/lib @OPENCL_FLAGS@ @LIBCURL_CFLAGS@
 
 # common sources
 cgminer_SOURCES := cgminer.c

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,9 @@ WS2_LIBS=""
 MATH_LIBS="-lm"
 
 case $target in
+  amd64-*)
+    have_x86_64=true
+    ;;
   x86_64-*)
     have_x86_64=true
     ;;
@@ -257,7 +260,7 @@ if test "x$curses" = "xno"; then
 else
 	AC_SEARCH_LIBS(addstr, ncurses pdcurses, [
 		curses=yes
-		cursesmsg="FOUND: ${ac_cv_search_addstr:2}"
+		cursesmsg="FOUND: ${ac_cv_search_addstr}"
 		AC_DEFINE([HAVE_CURSES], [1], [Defined to 1 if curses TUI support is wanted])
 	], [
 		if test "x$curses" = "xyes"; then


### PR DESCRIPTION
- Bashism in configure:
  ./configure: ${ac_cv_search_addstr:2}: Bad substitution
- Configure finds libcurl in /usr/local, but /usr/local/include isn't in CFLAGS:
  cgminer.c:39:10: fatal error: 'curl/curl.h' file not found
- Configure misdetects amd64 as 32-bit; fails when trying to link in sse2_64:
  cgminer-sha256_sse2_amd64.o: In function `scanhash_sse2_64':
  ./cgminer/sha256_sse2_amd64.c:98: undefined reference to`sha256_sse2_64_new'
  cgminer-sha256_sse4_amd64.o: In function `scanhash_sse4_64':
  ./cgminer/sha256_sse4_amd64.c:96: undefined reference to`CalcSha256_x64_sse4'
  ./cgminer/sha256_sse4_amd64.c:97: undefined reference to `CalcSha256_x64_sse4'
