### PR TITLE
libztex: avoid the use of libusb_error_name()

### DIFF
--- a/libztex.c
+++ b/libztex.c
@@ -69,7 +69,7 @@ static int libztex_get_string_descriptor_ascii(libusb_device_handle *dev, uint8_
 	    LIBUSB_REQUEST_GET_DESCRIPTOR, (LIBUSB_DT_STRING << 8) | 0,
 	    0x0000, buf, sizeof(buf), 1000);
 	if (cnt < 0) {
-		applog(LOG_ERR, "%s: Failed to read LANGIDs: %s", __func__, libusb_error_name(cnt));
+		applog(LOG_ERR, "%s: Failed to read LANGIDs: %d", __func__, cnt);
 		return cnt;
 	}
 
@@ -79,7 +79,7 @@ static int libztex_get_string_descriptor_ascii(libusb_device_handle *dev, uint8_
 	    LIBUSB_REQUEST_GET_DESCRIPTOR, (LIBUSB_DT_STRING << 8) | desc_index,
 	    langid, buf, sizeof(buf), 1000);
 	if (cnt < 0) {
-		applog(LOG_ERR, "%s: Failed to read string descriptor: %s", __func__, libusb_error_name(cnt));
+		applog(LOG_ERR, "%s: Failed to read string descriptor: %d", __func__, cnt);
 		return cnt;
 	}
 
@@ -106,7 +106,7 @@ static bool libztex_firmwareReset(struct libusb_device_handle *hndl, bool enable
 	int cnt = libusb_control_transfer(hndl, 0x40, 0xA0, 0xE600, 0, &reset, 1, 1000);
 	if (cnt < 0)
 	{
-		applog(LOG_ERR, "Ztex reset %d failed: %s", libusb_error_name(cnt), enable);
+		applog(LOG_ERR, "Ztex reset %d failed: %d", enable, cnt);
 		return 1;
 	}
 
@@ -136,7 +136,7 @@ static enum check_result libztex_checkDevice(struct libusb_device *dev)
 
 	err = libusb_open(dev, &hndl);
 	if (err != LIBUSB_SUCCESS) {
-		applog(LOG_ERR, "%s: Can not open ZTEX device: %s", __func__, libusb_error_name(err));
+		applog(LOG_ERR, "%s: Can not open ZTEX device: %d", __func__, err);
 		goto done;
 	}
 
@@ -267,7 +267,7 @@ static enum check_result libztex_checkDevice(struct libusb_device *dev)
 		int k = libusb_control_transfer(hndl, 0x40, 0xA0, i, 0, fw_buf + i, numbytes, 1000);
 		if (k < numbytes)
 		{
-			applog(LOG_ERR, "Ztex device: Failed to write firmware at %d with: %s", i, libusb_error_name(k));
+			applog(LOG_ERR, "Ztex device: Failed to write firmware at %d with err: %d", i, k);
 			goto done;
 		}
 	}
@@ -589,7 +589,7 @@ int libztex_prepare_device(struct libusb_device *dev, struct libztex_device** zt
 
 	err = libusb_open(dev, &newdev->hndl);
 	if (err != LIBUSB_SUCCESS) {
-		applog(LOG_ERR, "%s: Can not open ZTEX device: %s", __func__, libusb_error_name(err));
+		applog(LOG_ERR, "%s: Can not open ZTEX device: %d", __func__, err);
 		return CHECK_ERROR;
 	}
 
@@ -734,7 +734,7 @@ int libztex_scanDevices(struct libztex_dev_list*** devs_p)
 			err = libztex_checkDevice(list[i]);
 			switch (err) {
 			case CHECK_ERROR:
-				applog(LOG_ERR, "Ztex: Can not check device: %s", libusb_error_name(err));
+				applog(LOG_ERR, "Ztex: Can not check device: %d", err);
 				continue;
 			case CHECK_IS_NOT_ZTEX:
 				continue;


### PR DESCRIPTION
libusb_error_name() is only available in libusb-1.0.9 and newer
