### PR TITLE
driver-ztex: search the complete noncerange based on the actual speed

### DIFF
--- a/driver-ztex.c
+++ b/driver-ztex.c
@@ -151,7 +151,7 @@ static bool ztex_checkNonce(struct libztex_device *ztex,
                             struct libztex_hash_data *hdata)
 {
 	uint32_t *data32 = (uint32_t *)(work->data);
-	unsigned char swap[128];
+	unsigned char swap[80];
 	uint32_t *swap32 = (uint32_t *)swap;
 	unsigned char hash1[32];
 	unsigned char hash2[32];


### PR DESCRIPTION
search the complete noncerange until the range to the end is more
work than at the last round. doing one more round would mean we
would have a overrun, which is a waste.

with actual ztex boards this means that a new getwork is needed
every 19 seconds in general and not every 10 seconds (without
rollntime).
