### PR TITLE
increase receive buffer size. needed for Stratum to work with large coinbase transactions

### DIFF
--- a/miner.h
+++ b/miner.h
@@ -859,7 +859,7 @@ struct stratum_work {
 	double diff;
 };
 
-#define RECVSIZE 8192
+#define RECVSIZE 81920
 #define RBUFSIZE (RECVSIZE + 4)
 
 struct pool {


### PR DESCRIPTION
This fix is needed for P2Pool's Stratum support. Without it, cgminer fails to process the stratum notification (and crashes).

There's a p2pool node with stratum running at stratum+tcp://vps.forre.st:9332 for testing.
