### PR TITLE
Fix to can be compiled with cpuming on OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,7 @@ AC_CHECK_HEADERS(syslog.h)
 AC_FUNC_ALLOCA
 
 have_win32=false
+have_darwin=false
 PTHREAD_FLAGS="-lpthread"
 DLOPEN_FLAGS="-ldl"
 OPENCL_LIBS="-lOpenCL"
@@ -89,11 +90,13 @@ case $target in
     AC_DEFINE([_WIN32_WINNT], [0x0501], "WinNT version for XP+ support")
     ;;
   powerpc-*-darwin*)
+    have_darwin=true
     CFLAGS="$CFLAGS -faltivec"
     OPENCL_LIBS=""
     PTHREAD_FLAGS=""
     ;;
   *-*-darwin*)
+    have_darwin=true
     OPENCL_LIBS="-framework OpenCL"
     PTHREAD_FLAGS=""
 	;;
@@ -287,6 +290,7 @@ AM_CONDITIONAL([NEED_USBUTILS_C], [test x$bitforce$modminer$bflsc != xnonono])
 AM_CONDITIONAL([HAVE_CURSES], [test x$curses = xyes])
 AM_CONDITIONAL([WANT_JANSSON], [test x$request_jansson = xtrue])
 AM_CONDITIONAL([HAVE_WINDOWS], [test x$have_win32 = xtrue])
+AM_CONDITIONAL([HAVE_OSX], [test x$have_darwin = xtrue])
 AM_CONDITIONAL([HAVE_x86_64], [test x$have_x86_64 = xtrue])
 
 if test "x$bitforce$modminer$bflsc" != xnonono; then

--- a/x86_32/Makefile.am
+++ b/x86_32/Makefile.am
@@ -5,4 +5,12 @@ SUFFIXES = .asm
 libx8632_a_SOURCES	= sha256_xmm.asm
 
 .asm.o:
+if HAVE_WINDOWS
+	$(YASM) -f win32 $<
+else
+if HAVE_OSX
+	$(YASM) -f macho32 $<
+else
 	$(YASM) -f elf32 $<
+endif
+endif

--- a/x86_64/Makefile.am
+++ b/x86_64/Makefile.am
@@ -5,4 +5,12 @@ SUFFIXES = .asm
 libx8664_a_SOURCES	= sha256_xmm_amd64.asm sha256_sse4_amd64.asm
 
 .asm.o:
+if HAVE_WINDOWS
+	$(YASM) -f win64 $<
+else
+if HAVE_OSX
+	$(YASM) -f macho64 $<
+else
 	$(YASM) -f elf64 $<
+endif
+endif

--- a/x86_64/sha256_sse4_amd64.asm
+++ b/x86_64/sha256_sse4_amd64.asm
@@ -23,13 +23,14 @@ BITS 64
 
 %define LAB_LOOP_UNROLL 8
 
-extern g_4sha256_k
+extern _g_4sha256_k
 
-global CalcSha256_x64_sse4
+global _CalcSha256_x64_sse4
 ;	CalcSha256	hash(rdi), data(rsi), init(rdx)
-CalcSha256_x64_sse4:
+_CalcSha256_x64_sse4:
 
 	push	rbx
+	push	r8
 
 LAB_NEXT_NONCE:
 
@@ -127,6 +128,7 @@ LAB_CALC:
 
 	pop	rcx
 	mov	rax, 0
+	mov	r8, qword _g_4sha256_k
 
 ; Load the init values of the message into the hash.
 
@@ -148,8 +150,9 @@ LAB_LOOP:
 
 %macro	lab_loop_blk 0
 	movntdqa	xmm6, [data+rax*4]
-	paddd	xmm6, g_4sha256_k[rax*4]
+	paddd	xmm6, [r8]
 	add	rax, 4
+	add	r8, 16
 
 	paddd	xmm6, xmm10	; +h
 
@@ -254,6 +257,7 @@ LAB_LOOP:
 	movdqa	[hash+7*16], xmm10
 
 LAB_RET:
+	pop	r8
 	pop	rbx
 	ret
 

--- a/x86_64/sha256_xmm_amd64.asm
+++ b/x86_64/sha256_xmm_amd64.asm
@@ -311,7 +311,7 @@ sha256_sse2_64_new:
     movdqa    [hash1+7*16], rH
 
     mov       data, hash1
-    mov       init, sha256_init
+    mov       init, qword _sha256_init
 
     SHA_256
 


### PR DESCRIPTION
On OS X, cgminer can't be compiled when enable with cpu mining option. This commit is a fix to able cgminer can be compiled with cpu mining enable.
