### PR TITLE
Avalon-dev

### DIFF
--- a/driver-avalon.c
+++ b/driver-avalon.c
@@ -586,8 +586,8 @@ static bool avalon_detect_one(const char *devpath)
 	}
 	
 	avalon_infos = realloc(avalon_infos,
-			      sizeof(struct avalon_info *) *
-			      (total_devices + 1));
+			       sizeof(struct avalon_info *) *
+			       (total_devices + 1));
 
 	applog(LOG_INFO, "Avalon Detect: Found at %s, mark as %d",
 	       devpath, avalon->device_id);
@@ -618,14 +618,11 @@ static bool avalon_detect_one(const char *devpath)
 	info->temp_old = 0;
 	info->frequency = frequency;
 
-	/* Do something for failed reset ? */
-	if (0) {
-		/* Set asic to idle mode after detect */
-		avalon_idle(avalon);
-		avalon->device_fd = -1;
+	/* Set asic to idle mode after detect */
+	avalon_idle(avalon);
+	avalon->device_fd = -1;
 
-		avalon_close(fd);
-	}
+	avalon_close(fd);
 	return true;
 }
 


### PR DESCRIPTION
-    for some reason network down. one simple cgminer command:
    "cgminer -o 127.0.0.1:8888 -O fa:ke --avalon-options 115200:32:10:50:256"
  can idle the avalon for safe power and protect chip
  This is used at /etc/init.d/cgminer under OpenWrt. but I think it's useful/easy idle the Avalon.
-   if hash_count == 0; reinit avalon, fix the 0MHS bug
  use the max value of temp1 and temp2 for fan control
