### PR TITLE
Avalon

### DIFF
--- a/driver-avalon.c
+++ b/driver-avalon.c
@@ -947,7 +947,7 @@ static int64_t avalon_scanhash(struct thr_info *thr)
 	       info->fan0, info->fan1, info->fan2,
 	       info->temp0, info->temp1, info->temp2, info->temp_max);
 	info->temp_history_index++;
-	info->temp_sum += info->temp2;
+	info->temp_sum += avalon->temp;
 	applog(LOG_DEBUG, "Avalon: temp_index: %d, temp_count: %d, temp_old: %d",
 	       info->temp_history_index, info->temp_history_count, info->temp_old);
 	if (info->temp_history_index == info->temp_history_count) {


### PR DESCRIPTION
-    for some reason network down. one simple cgminer command:
  "cgminer -o 127.0.0.1:8888 -O fa:ke --avalon-options 115200:32:10:50:256"
  can idle the avalon for safe power and protect chip
  This is used at /etc/init.d/cgminer under OpenWrt. but I think it's useful/easy idle the Avalon.
-    if hash_count == 0; reinit avalon, fix the 0MHS bug
  use the max value of temp1 and temp2 for fan control
