### PR TITLE
avalon: if result_wrong >= get_work_count jump out the read loop

### DIFF
--- a/driver-avalon.c
+++ b/driver-avalon.c
@@ -908,6 +908,9 @@ static int64_t avalon_scanhash(struct thr_info *thr)
 			info->no_matching_work++;
 			result_wrong++;
 
+			if (result_wrong >= avalon_get_work_count)
+				break;
+
 			if (opt_debug) {
 				timersub(&tv_finish, &tv_start, &elapsed);
 				applog(LOG_DEBUG,"Avalon: no matching work: %d"


### PR DESCRIPTION
Sometimes the fpga controller give all wrong result and didn't change the buffer status
