### PR TITLE
compile on win32

### DIFF
--- a/util.c
+++ b/util.c
@@ -33,6 +33,7 @@
 # include <windows.h>
 # include <winsock2.h>
 # include <ws2tcpip.h>
+# include <mmsystem.h>
 #endif
 
 #include "miner.h"


### PR DESCRIPTION
On mingw32, we need include <mmsystem.h> manually.
