### PR TITLE
Update api.c

### DIFF
--- a/api.c
+++ b/api.c
@@ -1083,7 +1083,7 @@ static struct api_data *print_data(struct api_data *root, char *buf, bool isjson
 			case API_UTILITY:
 			case API_FREQ:
 			case API_MHS:
-				sprintf(buf, "%.2f", *((double *)(root->data)));
+				sprintf(buf, "%.3f", *((double *)(root->data)));
 				break;
 			case API_VOLTS:
 				sprintf(buf, "%.3f", *((float *)(root->data)));


### PR DESCRIPTION
I propose a change in the way API reports MHS so that it outputs 3 decimal places (".2f" -> ".3f") because lot's of miners mine for LTC now and this would be more appropriate to report as it would effectively report kHs at the same time it should not matter too much for miners mining BTC on ASICs...
