### PR TITLE
Updated api.c to send the hashrate with 3 decimal places, for scrypt miners

### DIFF
--- a/api.c
+++ b/api.c
@@ -1083,7 +1083,7 @@ static struct api_data *print_data(struct api_data *root, char *buf, bool isjson
 			case API_UTILITY:
 			case API_FREQ:
 			case API_MHS:
-				sprintf(buf, "%.2f", *((double *)(root->data)));
+				sprintf(buf, "%.3f", *((double *)(root->data)));
 				break;
 			case API_VOLTS:
 				sprintf(buf, "%.3f", *((float *)(root->data)));


### PR DESCRIPTION
Most GPU miners are switching over to LTC, and the cgminer api only returns mega hashes in the API which has to be multiplied by 1000 to get kilo hashes. I made the api return 3 decimal places to get accurate hash rates for scrypt miners.
