### PR TITLE
Add --cert option to allow self-certified https: JSON-RPC servers

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -233,7 +233,7 @@ static struct pool *currentpool = NULL;
 int total_pools, enabled_pools;
 enum pool_strategy pool_strategy = POOL_FAILOVER;
 int opt_rotate_period;
-static int total_urls, total_users, total_passes, total_userpasses;
+static int total_urls, total_certs, total_users, total_passes, total_userpasses;
 
 static
 #ifndef HAVE_CURSES
@@ -708,6 +708,20 @@ static char *set_url(char *arg)
 	return NULL;
 }
 
+static char *set_cert(char *arg)
+{
+	struct pool *pool;
+
+	total_certs++;
+	if (total_certs > total_pools)
+		add_pool();
+	pool = pools[total_certs - 1];
+
+	opt_set_charp(arg, &pool->rpc_cert);
+
+	return NULL;
+}
+
 static char *set_user(const char *arg)
 {
 	struct pool *pool;
@@ -954,6 +968,9 @@ static struct opt_table opt_config_table[] = {
 			opt_set_bool, &opt_bfl_noncerange,
 			"Use nonce range on bitforce devices if supported"),
 #endif
+	OPT_WITH_ARG("--cert|-C",
+		     set_cert, NULL, NULL,
+		     "Server certificate for self-signed https:// bitcoin JSON-RPC server"),
 #ifdef HAVE_CURSES
 	OPT_WITHOUT_ARG("--compact",
 			opt_set_bool, &opt_compact,
@@ -1660,7 +1677,8 @@ static void update_gbt(struct pool *pool)
 	if (unlikely(!curl))
 		quit (1, "CURL initialisation failed in update_gbt");
 
-	val = json_rpc_call(curl, pool->rpc_url, pool->rpc_userpass,
+	val = json_rpc_call(curl, pool->rpc_url, pool->rpc_cert,
+			    pool->rpc_userpass,
 			    pool->rpc_req, true, false, &rolltime, pool, false);
 
 	if (val) {
@@ -2545,7 +2563,9 @@ static bool submit_upstream_work(struct work *work, CURL *curl, bool resubmit)
 
 	cgtime(&tv_submit);
 	/* issue JSON-RPC request */
-	val = json_rpc_call(curl, pool->rpc_url, pool->rpc_userpass, s, false, false, &rolltime, pool, true);
+	val = json_rpc_call(curl, pool->rpc_url, pool->rpc_cert,
+			    pool->rpc_userpass,
+			    s, false, false, &rolltime, pool, true);
 	cgtime(&tv_submit_reply);
 	free(s);
 
@@ -2817,7 +2837,8 @@ static bool get_upstream_work(struct work *work, CURL *curl)
 
 	cgtime(&work->tv_getwork);
 
-	val = json_rpc_call(curl, url, pool->rpc_userpass, pool->rpc_req, false,
+	val = json_rpc_call(curl, url, pool->rpc_cert,
+			    pool->rpc_userpass, pool->rpc_req, false,
 			    false, &work->rolltime, pool, false);
 	pool_stats->getwork_attempts++;
 
@@ -3973,6 +3994,8 @@ void write_config(FILE *fcfg)
 			pools[i]->rpc_proxy ? json_escape(pools[i]->rpc_proxy) : "",
 			pools[i]->rpc_proxy ? "|" : "",
 			json_escape(pools[i]->rpc_url));
+		if (pools[i]->rpc_cert)
+			fprintf(fcfg, "\n\t\t\"cert\" : \"%s\",", json_escape(pools[i]->rpc_cert));
 		fprintf(fcfg, "\n\t\t\"user\" : \"%s\",", json_escape(pools[i]->rpc_user));
 		fprintf(fcfg, "\n\t\t\"pass\" : \"%s\"\n\t}", json_escape(pools[i]->rpc_pass));
 		}
@@ -5275,8 +5298,9 @@ retry_stratum:
 	/* Probe for GBT support on first pass */
 	if (!pool->probed && !opt_fix_protocol) {
 		applog(LOG_DEBUG, "Probing for GBT support");
-		val = json_rpc_call(curl, pool->rpc_url, pool->rpc_userpass,
-				    gbt_req, true, false, &rolltime, pool, false);
+		val = json_rpc_call(curl, pool->rpc_url, pool->rpc_cert,
+				    pool->rpc_userpass, gbt_req, true, false,
+				    &rolltime, pool, false);
 		if (val) {
 			bool append = false, submit = false;
 			json_t *res_val, *mutables;
@@ -5320,7 +5344,8 @@ retry_stratum:
 	}
 
 	cgtime(&tv_getwork);
-	val = json_rpc_call(curl, pool->rpc_url, pool->rpc_userpass,
+	val = json_rpc_call(curl, pool->rpc_url, pool->rpc_cert,
+			    pool->rpc_userpass,
 			    pool->rpc_req, true, false, &rolltime, pool, false);
 	cgtime(&tv_getwork_reply);
 
@@ -6331,7 +6356,8 @@ retry_pool:
 		 * so always establish a fresh connection instead of relying on
 		 * a persistent one. */
 		curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1);
-		val = json_rpc_call(curl, lp_url, pool->rpc_userpass,
+		val = json_rpc_call(curl, lp_url, pool->rpc_cert,
+				    pool->rpc_userpass,
 				    lpreq, false, true, &rolltime, pool, false);
 
 		cgtime(&reply);

--- a/miner.h
+++ b/miner.h
@@ -877,7 +877,8 @@ extern int swork_id;
 extern pthread_rwlock_t netacc_lock;
 
 extern const uint32_t sha256_init_state[];
-extern json_t *json_rpc_call(CURL *curl, const char *url, const char *userpass,
+extern json_t *json_rpc_call(CURL *curl, const char *url, const char *cert,
+			     const char *userpass,
 			     const char *rpc_req, bool, bool, int *,
 			     struct pool *pool, bool);
 extern const char *proxytype(curl_proxytype proxytype);
@@ -1107,6 +1108,7 @@ struct pool {
 
 	char *rpc_req;
 	char *rpc_url;
+	char *rpc_cert;
 	char *rpc_userpass;
 	char *rpc_user, *rpc_pass;
 	curl_proxytype rpc_proxytype;

--- a/util.c
+++ b/util.c
@@ -293,7 +293,7 @@ static int curl_debug_cb(__maybe_unused CURL *handle, curl_infotype type,
 	return 0;
 }
 
-json_t *json_rpc_call(CURL *curl, const char *url,
+json_t *json_rpc_call(CURL *curl, const char *url, const char *cert,
 		      const char *userpass, const char *rpc_req,
 		      bool probe, bool longpoll, int *rolltime,
 		      struct pool *pool, bool share)
@@ -326,6 +326,8 @@ json_t *json_rpc_call(CURL *curl, const char *url,
 
 	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
 	curl_easy_setopt(curl, CURLOPT_URL, url);
+	if (cert != NULL)
+		curl_easy_setopt(curl, CURLOPT_CAINFO, cert);
 	curl_easy_setopt(curl, CURLOPT_ENCODING, "");
 	curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
 


### PR DESCRIPTION
When using distributed miners to a central coin server, the RPC username
and password travel unencrypted over the net, allowing any snooper to empty
your wallet.  To defeat this, we would use https: but OpenSSL fails if the
certificate is self-signed, which is the normal case for weebs like me.

This patch adds a --cert option allowing users to supply the RPC server's
self-signed certificate.

The same modification has already been accepted by pooler/cpuminer
https://github.com/pooler/cpuminer/commit/805ea94a4d2701c99340e90501bac300b9aca63e
but here it has been adapted to the multiple-pool structure of cgminer, though tested only with a single pool.
