### PR TITLE
Avalon API stats only show matching work if > 0

### DIFF
--- a/driver-avalon.c
+++ b/driver-avalon.c
@@ -1375,8 +1375,10 @@ static struct api_data *avalon_api_stats(struct cgpu_info *cgpu)
 	for (i = 0; i < info->miner_count; i++) {
 		char mcw[24];
 
-		sprintf(mcw, "match_work_count%d", i + 1);
-		root = api_add_int(root, mcw, &(info->matching_work[i]), false);
+		if (info->matching_work[i]) {
+			sprintf(mcw, "match_work_count%d", i + 1);
+			root = api_add_int(root, mcw, &(info->matching_work[i]), false);
+		}
 	}
 
 	return root;


### PR DESCRIPTION
Avalon API stats only show matching work if > 0
