### PR TITLE
avalon: display the FPGA controller version on API

### DIFF
--- a/driver-avalon.h
+++ b/driver-avalon.h
@@ -125,6 +125,7 @@ struct avalon_info {
 	int matching_work[AVALON_DEFAULT_MINER_NUM];
 
 	int frequency;
+	uint32_t ctlr_ver;
 
 	struct thr_info *thr;
 	pthread_t read_thr;


### PR DESCRIPTION
Some of the last few bits of reset result have the FPGA controller version
