### PR TITLE
Fixed one byte stack overflow in mcast recvfrom.

### DIFF
--- a/api.c
+++ b/api.c
@@ -4278,7 +4278,7 @@ static void mcast()
 
 		count++;
 		came_from_siz = sizeof(came_from);
-		if (SOCKETFAIL(rep = recvfrom(mcast_sock, buf, sizeof(buf),
+		if (SOCKETFAIL(rep = recvfrom(mcast_sock, buf, sizeof(buf) - 1,
 						0, (struct sockaddr *)(&came_from), &came_from_siz))) {
 			applog(LOG_DEBUG, "API mcast failed count=%d (%s) (%d)",
 					count, SOCKERRMSG, (int)mcast_sock);


### PR DESCRIPTION
The actual overflow happens when enforcing the NULL termination shortly
after the recvfrom.
