### PR TITLE
Get Session Id Fix

### DIFF
--- a/util.c
+++ b/util.c
@@ -2233,28 +2233,38 @@ static bool setup_stratum_socket(struct pool *pool)
 
 static char *get_sessionid(json_t *val)
 {
-	char *ret = NULL;
+	char *ret = NULL, *notify; 
 	json_t *arr_val;
-	int arrsize, i;
+	int val_size, vi, arrsize, i;        
+         
+        val_size = json_array_size(val);        
+        for(vi = 0; vi < val_size; ++vi){
+            arr_val = json_array_get(val, vi);
+            if (!arr_val || !json_is_array(arr_val))
+                goto out;    
 
-	arr_val = json_array_get(val, 0);
-	if (!arr_val || !json_is_array(arr_val))
-		goto out;
-	arrsize = json_array_size(arr_val);
-	for (i = 0; i < arrsize; i++) {
-		json_t *arr = json_array_get(arr_val, i);
-		char *notify;
-
-		if (!arr | !json_is_array(arr))
-			break;
-		notify = __json_array_string(arr, 0);
-		if (!notify)
-			continue;
-		if (!strncasecmp(notify, "mining.notify", 13)) {
-			ret = json_array_string(arr, 1);
-			break;
-		}
-	}
+            notify = __json_array_string(arr_val, 0);
+            if (notify){
+                if (!strncasecmp(notify, "mining.notify", 13)){                       
+                    ret = json_array_string(arr_val, 1);
+                    goto out;
+                }
+            }
+            
+            arrsize = json_array_size(arr_val);  
+            for (i = 0; i < arrsize; ++i) {
+                json_t *arr = json_array_get(arr_val, i);                                                      
+                if (!arr | !json_is_array(arr))                        
+                    break;                    
+                notify = __json_array_string(arr, 0);
+                if (!notify)
+                    continue;                    
+                if (!strncasecmp(notify, "mining.notify", 13)){                       
+                    ret = json_array_string(arr, 1);
+                    goto out;
+                }       
+            }
+        }
 out:
 	return ret;
 }


### PR DESCRIPTION
Get session id fails when there is one nested array:
{result:[["mining.notify","unqStr"],"0002",4]}
It looks for a second nested array:
{result:[[["mining.notify","unqStr"],["etc"]],"0003",4]}

This will try to find unqStr starting from first array.
