### PR TITLE
Running cgminer w/o internet connection and next internet resume cause pools forever not active error.

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -8213,8 +8213,6 @@ int main(int argc, char *argv[])
 
 	applog(LOG_NOTICE, "Probing for an alive pool");
 	do {
-		int slept = 0;
-
 		/* Look for at least one active pool before starting */
 		probe_pools();
 


### PR DESCRIPTION
halfdelay(n); where n must be between 1 and 255. Use halfdelay(600) cause that pool_active check only once. You can reproduce this by running cgminer without internet connections, when resume connection but pools check never comes + in log u see "Press any key to exit, or cgminer will try again in 60s" only one time.
I also removed sleep(1); 60 times because if we click any key for exit we should wait for 60 seconds anyway. halfdelay(200) = 20sec delay I suppose good enough.
