### PR TITLE
Fix idle bug, when redirected client can't auth

### DIFF
--- a/util.c
+++ b/util.c
@@ -2025,6 +2025,8 @@ bool auth_stratum(struct pool *pool)
 		applog(LOG_INFO, "pool %d JSON stratum auth failed: %s", pool->pool_no, ss);
 		free(ss);
 
+		suspend_stratum(pool);
+
 		goto out;
 	}
 


### PR DESCRIPTION
This bug comes up at the following situations:
The miner is redirected to other host by client.reconnect method. But the new host rejected the authorization. And 1 minutes later, cgminer detect as alive, because the pool isn't idle (successful subscribed).  If this pool has higher priority, miner switch to this pool. But, because the miner doesnt authed yet, doesnt get any work, hash goes to 0.

This patch force disconnect the miner, if auth is failed.
