### PR TITLE
Prevent a segfault when writing a config file containing 'rotate' option

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -772,10 +772,10 @@ static char *set_loadbalance(enum pool_strategy *strategy)
 	return NULL;
 }
 
-static char *set_rotate(const char *arg, int *i)
+static char *set_rotate(const char *arg, char __maybe_unused *i)
 {
 	pool_strategy = POOL_ROTATE;
-	return set_int_range(arg, i, 0, 9999);
+	return set_int_range(arg, &opt_rotate_period, 0, 9999);
 }
 
 static char *set_rr(enum pool_strategy *strategy)
@@ -1371,7 +1371,7 @@ static struct opt_table opt_config_table[] = {
 		     set_null, NULL, &opt_set_null,
 		     opt_hidden),
 	OPT_WITH_ARG("--rotate",
-		     set_rotate, opt_show_intval, &opt_rotate_period,
+		     set_rotate, NULL, &opt_set_null,
 		     "Change multipool strategy from failover to regularly rotate at N minutes"),
 	OPT_WITHOUT_ARG("--round-robin",
 		     set_rr, &pool_strategy,


### PR DESCRIPTION
When saving a configuration the rotate option is being inadvertently handled as a string option, causing a segfault on line cgminer.c:4844 when json_escape is called from cgminer.c:4937. The cause is opt->u.arg points to an integer, but is cast to char\* and passed to json_escape, where the int\* will have strlen called on it.

Since rotate is being handled specially a few lines down this patch simply ignores the rotate option when writing the other string parameters to file. There could be other variations on how to handle it.

Credit to LinuxETC and Sling00 for first discovering it.
