### PR TITLE
A1: add support for updated product variants, small fixes

### DIFF
--- a/A1-board-selector-CCD.c
+++ b/A1-board-selector-CCD.c
@@ -26,69 +26,66 @@
 #include "miner.h"
 
 #include "A1-board-selector.h"
+#include "i2c-context.h"
 
 static struct board_selector ccd_selector;
 
-struct ccd_ctx {
-	struct i2c_ctx U1_tca9535;
-	uint8_t board_mask;
-	uint8_t active_board;
-	pthread_mutex_t lock;
-};
+struct i2c_ctx *U1_tca9535;
+uint8_t chain_mask = 0xff;
+uint8_t active_chain = 255;
+pthread_mutex_t lock;
 
-static struct ccd_ctx ccd_ctx = {
-	.U1_tca9535 = { .addr = 0x27, .file = -1 },
-	.board_mask = 0xff,
-	.active_board = 255,
-};
 
 #define UNUSED_BITS 0xe0
 
 static void ccd_unlock(void)
 {
-	mutex_unlock(&ccd_ctx.lock);
+	mutex_unlock(&lock);
 }
 
 static void ccd_exit(void)
 {
-	i2c_slave_close(&ccd_ctx.U1_tca9535);
+	if (U1_tca9535 != NULL)
+		U1_tca9535->exit(U1_tca9535);
 }
+uint8_t retval = 0;
 
 extern struct board_selector *ccd_board_selector_init(void)
 {
-	mutex_init(&ccd_ctx.lock);
-	struct i2c_ctx *ctx = &ccd_ctx.U1_tca9535;
-	bool retval =	i2c_slave_open(ctx, I2C_BUS) &&
-			i2c_slave_write(ctx, 0x06, 0xe0) &&
-			i2c_slave_write(ctx, 0x07, 0xe0) &&
-			i2c_slave_write(ctx, 0x02, 0x1f) &&
-			i2c_slave_write(ctx, 0x03, 0x00);
+	mutex_init(&lock);
+	U1_tca9535 = i2c_slave_open(I2C_BUS, 0x27);
+	if (U1_tca9535 == NULL)
+		return NULL;
+	bool retval =	U1_tca9535->write(U1_tca9535, 0x06, 0xe0) &&
+			U1_tca9535->write(U1_tca9535, 0x07, 0xe0) &&
+			U1_tca9535->write(U1_tca9535, 0x02, 0x1f) &&
+			U1_tca9535->write(U1_tca9535, 0x03, 0x00);
 	if (retval)
 		return &ccd_selector;
 	ccd_exit();
 	return NULL;
 }
 
-static bool ccd_select(uint8_t board)
+static bool ccd_select(uint8_t chain)
 {
-	if (board >= CCD_MAX_CHAINS)
+	if (chain >= CCD_MAX_CHAINS)
 		return false;
 
-	mutex_lock(&ccd_ctx.lock);
-	if (ccd_ctx.active_board == board)
+	mutex_lock(&lock);
+	if (active_chain == chain)
 		return true;
 
-	ccd_ctx.active_board = board;
-	ccd_ctx.board_mask = 1 << ccd_ctx.active_board;
-	return i2c_slave_write(&ccd_ctx.U1_tca9535, 0x02, ~ccd_ctx.board_mask);
+	active_chain = chain;
+	chain_mask = 1 << active_chain;
+	return U1_tca9535->write(U1_tca9535, 0x02, ~chain_mask);
 }
 
 static bool __ccd_board_selector_reset(uint8_t mask)
 {
-	if (!i2c_slave_write(&ccd_ctx.U1_tca9535, 0x03, mask))
+	if (!U1_tca9535->write(U1_tca9535, 0x03, mask))
 		return false;
 	cgsleep_ms(RESET_LOW_TIME_MS);
-	if (!i2c_slave_write(&ccd_ctx.U1_tca9535, 0x03, 0x00))
+	if (!U1_tca9535->write(U1_tca9535, 0x03, 0x00))
 		return false;
 	cgsleep_ms(RESET_HI_TIME_MS);
 	return true;
@@ -96,14 +93,14 @@ static bool __ccd_board_selector_reset(uint8_t mask)
 // we assume we are already holding the mutex
 static bool ccd_reset(void)
 {
-	return __ccd_board_selector_reset(ccd_ctx.board_mask);
+	return __ccd_board_selector_reset(chain_mask);
 }
 
 static bool ccd_reset_all(void)
 {
-	mutex_lock(&ccd_ctx.lock);
+	mutex_lock(&lock);
 	bool retval = __ccd_board_selector_reset(0xff & ~UNUSED_BITS);
-	mutex_unlock(&ccd_ctx.lock);
+	mutex_unlock(&lock);
 	return retval;
 }
 
@@ -114,6 +111,7 @@ static struct board_selector ccd_selector = {
 	.exit = ccd_exit,
 	.reset = ccd_reset,
 	.reset_all = ccd_reset_all,
-	.get_temp = dummy_u8,
+	/* don't have a temp sensor dedicated to chain */
+	.get_temp = dummy_get_temp,
 };
 

--- a/A1-board-selector.h
+++ b/A1-board-selector.h
@@ -8,26 +8,37 @@
 #define RESET_HI_TIME_MS  100
 
 struct board_selector {
-	bool (*select)(uint8_t board);
-	void (*release)(void);
+	/* destructor */
 	void (*exit)(void);
+	/* select board and chip chain for given chain index*/
+	bool (*select)(uint8_t chain);
+	/* release access to selected chain */
+	void (*release)(void);
+	/* reset currently selected chain */
 	bool (*reset)(void);
+	/* reset all chains on board */
 	bool (*reset_all)(void);
-	uint8_t (*get_temp)(void);
+	/* get temperature for selected chain at given sensor */
+	uint8_t (*get_temp)(uint8_t sensor);
+	/* prepare board (voltage) for given sys_clock */
+	bool (*prepare_clock)(int clock_khz);
 };
 
 static bool dummy_select(uint8_t b) { (void)b; return true; }
 static void dummy_void(void) { };
 static bool dummy_bool(void) { return true; }
-static uint8_t dummy_u8(void) { return 0; }
+//static uint8_t dummy_u8(void) { return 0; }
+static uint8_t dummy_get_temp(uint8_t s) { (void)s; return 0; }
+static bool dummy_prepare_clock(int c) { (void)c; return true; }
 
 static const struct board_selector dummy_board_selector = {
+	.exit = dummy_void,
 	.select = dummy_select,
 	.release = dummy_void,
-	.exit = dummy_void,
 	.reset = dummy_bool,
 	.reset_all = dummy_bool,
-	.get_temp = dummy_u8,
+	.get_temp = dummy_get_temp,
+	.prepare_clock = dummy_prepare_clock,
 };
 
 /* CoinCraft Desk and Rig board selector constructors */
@@ -35,20 +46,5 @@ static const struct board_selector dummy_board_selector = {
 #define CCR_MAX_CHAINS	16
 extern struct board_selector *ccd_board_selector_init(void);
 extern struct board_selector *ccr_board_selector_init(void);
-
-
-/* common i2c context */
-struct i2c_ctx {
-	uint8_t addr;
-	int file;
-};
-
-/* the default I2C bus on RPi */
-#define I2C_BUS		"/dev/i2c-1"
-
-extern bool i2c_slave_write(struct i2c_ctx *ctx, uint8_t reg, uint8_t val);
-extern bool i2c_slave_read(struct i2c_ctx *ctx, uint8_t reg, uint8_t *val);
-extern bool i2c_slave_open(struct i2c_ctx *ctx, char *i2c_bus);
-extern void i2c_slave_close(struct i2c_ctx *ctx);
 
 #endif /* A1_BOARD_SELECTOR_H */

--- a/A1-common.h
+++ b/A1-common.h
@@ -62,6 +62,8 @@ struct A1_chain {
 
 	struct work_queue active_wq;
 
+	/* mark chain disabled, do not try to re-enable it */
+	bool disabled;
 	uint8_t temp;
 	int last_temp_time;
 };

--- a/Makefile.am
+++ b/Makefile.am
@@ -89,6 +89,7 @@ cgminer_SOURCES += A1-common.h
 cgminer_SOURCES += A1-board-selector.h
 cgminer_SOURCES += A1-board-selector-CCD.c A1-board-selector-CCR.c
 cgminer_SOURCES += A1-trimpot-mcp4x.h A1-trimpot-mcp4x.c
+cgminer_SOURCES += i2c-context.c i2c-context.h
 endif
 
 if HAS_DRILLBIT

--- a/i2c-context.c
+++ b/i2c-context.c
@@ -1,0 +1,102 @@
+/*
+ * generic I2C slave access interface
+ *
+ * Copyright 2014 Zefir Kurtisi <zefir.kurtisi@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.  See COPYING for more details.
+ */
+
+
+#include <sys/ioctl.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <linux/i2c.h>
+#include <linux/i2c-dev.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <assert.h>
+
+#include "miner.h"
+#include "i2c-context.h"
+
+
+static bool i2c_slave_write(struct i2c_ctx *ctx, uint8_t reg, uint8_t val)
+{
+	union i2c_smbus_data data;
+	data.byte = val;
+
+	struct i2c_smbus_ioctl_data args;
+
+	args.read_write = I2C_SMBUS_WRITE;
+	args.command = reg;
+	args.size = I2C_SMBUS_BYTE_DATA;
+	args.data = &data;
+
+	if (ioctl(ctx->file, I2C_SMBUS, &args) == -1) {
+		applog(LOG_INFO, "i2c 0x%02x: failed to write to fdesc %d: %s",
+		       ctx->addr, ctx->file, strerror(errno));
+		return false;
+	}
+	applog(LOG_DEBUG, "I2C-W(0x%02x/0x%02x)=0x%02x", ctx->addr, reg, val);
+	return true;
+}
+
+static bool i2c_slave_read(struct i2c_ctx *ctx, uint8_t reg, uint8_t *val)
+{
+	union i2c_smbus_data data;
+	struct i2c_smbus_ioctl_data args;
+
+	args.read_write = I2C_SMBUS_READ;
+	args.command = reg;
+	args.size = I2C_SMBUS_BYTE_DATA;
+	args.data = &data;
+
+	if (ioctl(ctx->file, I2C_SMBUS, &args) == -1) {
+		applog(LOG_INFO, "i2c 0x%02x: failed to read from fdesc %d: %s",
+		       ctx->addr, ctx->file, strerror(errno));
+		return false;
+	}
+	*val = data.byte;
+	applog(LOG_DEBUG, "I2C-R(0x%02x/0x%02x)=0x%02x", ctx->addr, reg, *val);
+	return true;
+}
+
+static void i2c_slave_exit(struct i2c_ctx *ctx)
+{
+	if (ctx->file == -1)
+		return;
+	close(ctx->file);
+	free(ctx);
+}
+
+extern struct i2c_ctx *i2c_slave_open(char *i2c_bus, uint8_t slave_addr)
+{
+	int file = open(i2c_bus, O_RDWR);
+	if (file < 0) {
+		applog(LOG_INFO, "Failed to open i2c-1: %s", strerror(errno));
+		return NULL;
+	}
+
+	if (ioctl(file, I2C_SLAVE, slave_addr) < 0) {
+		close(file);
+		return NULL;
+	}
+	struct i2c_ctx *ctx = malloc(sizeof(*ctx));
+	assert(ctx != NULL);
+
+	ctx->addr = slave_addr;
+	ctx->file = file;
+	ctx->exit = i2c_slave_exit;
+	ctx->read = i2c_slave_read;
+	ctx->write = i2c_slave_write;
+	return ctx;
+}
+

--- a/i2c-context.h
+++ b/i2c-context.h
@@ -1,0 +1,26 @@
+#ifndef I2C_CONTEXT_H
+#define I2C_CONTEXT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* common i2c context */
+struct i2c_ctx {
+	/* destructor */
+	void (*exit)(struct i2c_ctx *ctx);
+	/* write one byte to given register */
+	bool (*write)(struct i2c_ctx *ctx, uint8_t reg, uint8_t val);
+	/* read one byte from given register */
+	bool (*read)(struct i2c_ctx *ctx, uint8_t reg, uint8_t *val);
+
+	/* common data */
+	uint8_t addr;
+	int file;
+};
+
+/* the default I2C bus on RPi */
+#define I2C_BUS		"/dev/i2c-1"
+
+extern struct i2c_ctx *i2c_slave_open(char *i2c_bus, uint8_t slave_addr);
+
+#endif /* I2C_CONTEXT_H */


### PR DESCRIPTION
This patch includes:
- generalize I2C slave access
- adapt CoinCraft Rig board selector to new design
- add support for single chip chains
- adapt verbosity levels
- check for chip clocks below 100MHz
