### PR TITLE
Hashfast voltage support

### DIFF
--- a/ASIC-README
+++ b/ASIC-README
@@ -236,7 +236,7 @@ ASIC SPECIFIC COMMANDS
 --hfa-fan <arg>     Set fanspeed percentage for hashfast, single value or range (default: 10-85)
 --hfa-name <arg>    Set a unique name for a single hashfast device specified with --usb or the first device found
 --hfa-noshed        Disable hashfast dynamic core disabling feature
---hfa-options <arg> Set hashfast options name:clock (comma separated)
+--hfa-options <arg> Set hashfast options name:clock or name:clock@voltage (comma separated)
 --hfa-temp-overheat <arg> Set the hashfast overheat throttling temperature (default: 95)
 --hfa-temp-target <arg> Set the hashfast target temperature (0 to disable) (default: 88)
 --klondike-options <arg> Set klondike options clock:temptarget
@@ -606,20 +606,22 @@ If you wished to name the second device Slug you would add the commands:
 Newer firmwares on hashfast devices dynamically disable cores that generate
 invalid data. This command will disable this feature where possible.
 
---hfa-options <arg> Set hashfast options name:clock (comma separated)
+--hfa-options <arg> Set hashfast options name:clock or clock@voltage (comma separated)
 
 This command allows you to set options for each discrete hashfast device by
 its name (if the firmware has naming support, i.e. version 0.3+). Currently
-this takes only one option, the clock speed, although future options may be
-added.
+this takes as option the clock speed alone or clock speed and voltage, 
+although future options may be added.
 e.g.:
---hfa-options "rabbit:650,turtle:550"
+--hfa-options "rabbit:650,turtle:550@800"
 
-Would set a device named rabbit to clock speed 650 and the one named turtle to
-550. Starting the device at a speed where it is most stable will give more
-reliable hashrates long term and prevent it interacting with other devices,
-rather than depending on the clockdown feature in cgminer.
+Would set a device named rabbit to clock speed 650 MHz using default voltage
+and the one named turtle to 550 MHz using a voltage of 800 mv. Starting the
+device at a speed where it is most stable will give more reliable hashrates
+long term and prevent it interacting with other devices, rather than depending
+on the clockdown feature in cgminer.
 
+Note: Setting voltage cause a board reset and hotplug event on cgminer startup.
 
 Other undocumented hashfast command line options are for development purposes
 only at this stage and serve no useful purpose to end users.

--- a/driver-hashfast.c
+++ b/driver-hashfast.c
@@ -181,6 +181,30 @@ retry:
 	return true;
 }
 
+static bool hfa_send_generic_frame(struct cgpu_info *hashfast, uint8_t opcode, uint8_t chip_address,
+				   uint8_t core_address, uint16_t hdata, uint8_t *data, int len)
+{
+	uint8_t packet[256];
+	struct hf_header *p = (struct hf_header *)packet;
+	int tx_length, ret, amount;
+
+	p->preamble = HF_PREAMBLE;
+	p->operation_code = opcode;
+	p->chip_address = chip_address;
+	p->core_address = core_address;
+	p->hdata = htole16(hdata);
+	p->data_length = len / 4;
+	p->crc8 = hfa_crc8(packet);
+
+	if (len)
+		memcpy(&packet[sizeof(struct hf_header)], data, len);
+	tx_length = sizeof(struct hf_header) + len;
+
+	ret = usb_write(hashfast, (char *)packet, tx_length, &amount, C_NULL);
+
+	return ((ret >= 0) && (amount == tx_length));
+}
+
 static bool hfa_send_frame(struct cgpu_info *hashfast, uint8_t opcode, uint16_t hdata,
 			   uint8_t *data, int len)
 {
@@ -368,6 +392,47 @@ static void hfa_choose_opname(struct cgpu_info *hashfast, struct hashfast_info *
 		sprintf(info->op_name, "%lx", (long unsigned int)usecs);
 	}
 	hfa_write_opname(hashfast, info);
+}
+
+// Generic setting header
+struct hf_settings_data {
+	uint8_t revision;
+	uint8_t ref_frequency;
+	uint16_t magic;
+	uint16_t frequency0;
+	uint16_t voltage0;
+	uint16_t frequency1;
+	uint16_t voltage1;
+	uint16_t frequency2;
+	uint16_t voltage2;
+	uint16_t frequency3;
+	uint16_t voltage3;
+} __attribute__((packed,aligned(4)));
+
+static bool hfa_set_voltages(struct cgpu_info *hashfast, struct hashfast_info *info)
+{
+	uint16_t magic = 0x42AA;
+	struct hf_settings_data op_settings_data;
+
+	op_settings_data.revision = 1;
+	op_settings_data.ref_frequency = 25;
+	op_settings_data.magic = magic;
+
+	op_settings_data.frequency0 = info->hash_clock_rate;
+	op_settings_data.voltage0 = info->hash_voltage;
+	op_settings_data.frequency1 = info->hash_clock_rate;
+	op_settings_data.voltage1 = info->hash_voltage;
+	op_settings_data.frequency2 = info->hash_clock_rate;
+	op_settings_data.voltage2 = info->hash_voltage;
+	op_settings_data.frequency3 = info->hash_clock_rate;
+	op_settings_data.voltage3 = info->hash_voltage;
+
+	hfa_send_generic_frame(hashfast, OP_SETTINGS, 0x00, 0x01, magic, (uint8_t *)&op_settings_data, sizeof(op_settings_data));
+	// reset the board once to switch to new voltage settings
+	hfa_send_generic_frame(hashfast, OP_POWER, 0xff, 0x00, 0x1, NULL, 0);
+	hfa_send_generic_frame(hashfast, OP_POWER, 0xff, 0x00, 0x2, NULL, 0);
+
+	return true;
 }
 
 static bool hfa_send_shutdown(struct cgpu_info *hashfast);
@@ -645,7 +710,7 @@ static void hfa_set_clock(struct cgpu_info *hashfast, struct hashfast_info *info
  * to be added in the future. */
 static void hfa_check_options(struct hashfast_info *info)
 {
-	char *p, *options, *found = NULL;
+	char *p, *options, *found = NULL, *marker;
 	int maxlen, option = 0;
 
 	if (!opt_hfa_options)
@@ -688,6 +753,17 @@ static void hfa_check_options(struct hashfast_info *info)
 					break;
 				}
 				info->hash_clock_rate = lval;
+				marker = strchr(p,'@');
+				if (marker != NULL) {
+					lval = strtol(marker+1, NULL, 10);
+					if (lval < HFA_VOLTAGE_MIN || lval > HFA_VOLTAGE_MAX) {
+						applog(LOG_ERR, "Invalid core voltage %ld set with hashfast option for %s",
+						       lval, info->op_name);
+						break;
+					}
+					info->hash_voltage = lval;
+					info->set_voltage_needed = true;
+				}
 				break;
 		}
 	}
@@ -1224,6 +1300,7 @@ static void *hfa_read(void *arg)
 			case OP_USB_NOTICE:
 				hfa_parse_notice(hashfast, h);
 				break;
+			case OP_POWER:
 			case OP_PING:
 				/* Do nothing */
 				break;
@@ -1320,6 +1397,13 @@ static bool hfa_init(struct thr_info *thr)
 		}
 	}
 
+	if (info->set_voltage_needed) {
+		applog(LOG_NOTICE, "%s: Set default clock and voltage to %dMHz@%dmV",
+			hashfast->drv->name, info->hash_clock_rate, info->hash_voltage);
+		hfa_set_voltages(hashfast, info);
+		info->set_voltage_needed = false;
+	}
+
 	mutex_init(&info->lock);
 	mutex_init(&info->rlock);
 	if (pthread_create(&info->read_thr, NULL, hfa_read, (void *)thr))
@@ -1339,7 +1423,7 @@ out:
 		hashfast->device_data = NULL;
 		usb_nodev(hashfast);
 	}
-		
+
 	return ret;
 }
 

--- a/driver-hashfast.h
+++ b/driver-hashfast.h
@@ -43,6 +43,12 @@ char *opt_hfa_options;
 #define HFA_FAN_DEFAULT 33
 #define HFA_FAN_MAX 85
 #define HFA_FAN_MIN 5
+#define HFA_VOLTAGE_MAX 1000
+#define HFA_VOLTAGE_MIN 500
+
+// # Factory Operation Codes
+#define OP_SETTINGS             55      // Read or write settings
+#define OP_POWER                57
 
 // Matching fields for hf_statistics, but large #s for local accumulation, per-die
 struct hf_long_statistics {
@@ -145,6 +151,8 @@ struct hashfast_info {
 	int fanspeed;                               // Fanspeed in percent
 	int last_die_adjusted;
 	int clock_offset;
+	int hash_voltage;                           // Hash voltage to use, in mV
+	bool set_voltage_needed;
 
 	pthread_t read_thr;
 	time_t last_restart;


### PR DESCRIPTION
Here is a new change that allow voltage selection for Hashfast devices.

The voltage value is set for all device cores.

When setting voltage the board need a reset so you will see a hotplug event on every cgminer startup.
