### PR TITLE
Fix an off-by-one.

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -2111,7 +2111,7 @@ static void gbt_merkle_bins(struct pool *pool, json_t *transaction_arr)
 	memset(hashbin, 0, 32);
 	binleft = binlen / 32;
 	if (pool->transactions) {
-		int len = 1, ofs = 0;
+		int len = 0, ofs = 0;
 		const char *txn;
 
 		for (i = 0; i < pool->transactions; i++) {


### PR DESCRIPTION
This caused submitblock to have an undefined byte resulting
in bad block data.
