### PR TITLE
Avalon Nano: Add support Avalon Nano usb miner

### DIFF
--- a/01-cgminer.rules
+++ b/01-cgminer.rules
@@ -9,6 +9,7 @@ ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", SUBSYSTEM=="usb", ACTION=="ad
 
 # Icarus
 ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", SUBSYSTEM=="usb", ACTION=="add", MODE="0666", GROUP="plugdev"
+ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0083", SUBSYSTEM=="usb", ACTION=="add", MODE="0666", GROUP="plugdev"
 
 # AsicminerUSB and Antminer U1
 ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SUBSYSTEM=="usb", ACTION=="add", MODE="0666", GROUP="plugdev"

--- a/driver-icarus.c
+++ b/driver-icarus.c
@@ -534,6 +534,8 @@ static void icarus_initialise(struct cgpu_info *icarus, int baud)
 			_transfer(icarus, CP210X_TYPE_OUT, CP210X_REQUEST_BAUD, 0,
 				 interface, &data, sizeof(data), C_SETBAUD);
 			break;
+ 		case IDENT_AVA:
+ 			break;
 		default:
 			quit(1, "icarus_intialise() called with invalid %s cgid %i ident=%d",
 				icarus->drv->name, icarus->cgminer_id, ident);
@@ -649,6 +651,7 @@ static void set_timing_mode(int this_option_offset, struct cgpu_info *icarus)
 	ident = usb_ident(icarus);
 	switch (ident) {
 		case IDENT_ICA:
+		case IDENT_AVA:
 			info->Hs = ICARUS_REV3_HASH_TIME;
 			read_count_timing = ICARUS_READ_COUNT_TIMING;
 			break;
@@ -828,6 +831,7 @@ static void get_options(int this_option_offset, struct cgpu_info *icarus, int *b
 		case IDENT_ICA:
 		case IDENT_BLT:
 		case IDENT_LLT:
+		case IDENT_AVA:
 			*baud = ICARUS_IO_SPEED;
 			*work_division = 2;
 			*fpga_count = 2;
@@ -1114,6 +1118,7 @@ static struct cgpu_info *icarus_detect_one(struct libusb_device *dev, struct usb
 	info->ident = usb_ident(icarus);
 	switch (info->ident) {
 		case IDENT_ICA:
+        case IDENT_AVA:
 		case IDENT_BLT:
 		case IDENT_LLT:
 		case IDENT_AMU:
@@ -1163,7 +1168,7 @@ cmr2_retry:
 			continue;
 
 		memset(nonce_bin, 0, sizeof(nonce_bin));
-		ret = icarus_get_nonce(icarus, nonce_bin, &tv_start, &tv_finish, NULL, 100);
+		ret = icarus_get_nonce(icarus, nonce_bin, &tv_start, &tv_finish, NULL, 300);
 		if (ret != ICA_NONCE_OK)
 			continue;
 

--- a/usbutils.c
+++ b/usbutils.c
@@ -296,6 +296,20 @@ static struct usb_intinfo ica_ints[] = {
 	USB_EPS(0, ica_epinfos)
 };
 
+static struct usb_epinfo ica1_epinfos0[] = {
+	{ LIBUSB_TRANSFER_TYPE_INTERRUPT,	16,	EPI(0x82), 0, 0 }
+};
+
+static struct usb_epinfo ica1_epinfos1[] = {
+	{ LIBUSB_TRANSFER_TYPE_BULK,	64,	EPI(0x81), 0, 0 },
+	{ LIBUSB_TRANSFER_TYPE_BULK,	64,	EPO(0x01), 0, 0 }
+};
+
+static struct usb_intinfo ica1_ints[] = {
+	USB_EPS(1, ica1_epinfos1),
+	USB_EPS(0, ica1_epinfos0)
+};
+
 static struct usb_epinfo amu_epinfos[] = {
 	{ LIBUSB_TRANSFER_TYPE_BULK,	64,	EPI(1), 0, 0 },
 	{ LIBUSB_TRANSFER_TYPE_BULK,	64,	EPO(1), 0, 0 }
@@ -642,6 +656,16 @@ static struct usb_find_devices find_dev[] = {
 		.timeout = ICARUS_TIMEOUT_MS,
 		.latency = LATENCY_UNUSED,
 		INTINFO(ica_ints) },
+ 	{
+ 		.drv = DRIVER_icarus,
+ 		.name = "ICA",
+ 		.ident = IDENT_AVA,
+ 		.idVendor = 0x1fc9,
+ 		.idProduct = 0x0083,
+ 		.config = 1,
+ 		.timeout = ICARUS_TIMEOUT_MS,
+ 		.latency = LATENCY_UNUSED,
+ 		INTINFO(ica1_ints) },
 	{
 		.drv = DRIVER_icarus,
 		.name = "AMU",


### PR DESCRIPTION
Add support Avalon Nano usb miner, using --enable-icarus while run configure
