### PR TITLE
undeclared identifier 'IPV6_ADD_MEMBERSHIP' fix for apple

### DIFF
--- a/api.c
+++ b/api.c
@@ -121,6 +121,11 @@ char *WSAErrorMsg(void) {
 }
 #endif
 
+#if defined(__APPLE__)
+#define IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
+#define IPV6_DROP_MEMBERSHIP IPV6_LEAVE_GROUP
+#endif
+
 static const char *UNAVAILABLE = " - API will not be available";
 static const char *MUNAVAILABLE = " - API multicast listener will not be available";
 


### PR DESCRIPTION
This appears to fix the following compile error
CC       cgminer-api.o
api.c:4711:56: error: use of undeclared identifier 'IPV6_ADD_MEMBERSHIP'
  ...if (SOCKETFAIL(setsockopt(mcast_sock, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP,
                                                         ^
./util.h:13:26: note: expanded from macro 'SOCKETFAIL'
        #define SOCKETFAIL(a) ((a) < 0)
                                ^
1 error generated.
make[2]: **\* [cgminer-api.o] Error 1
make[1]: **\* [all-recursive] Error 1
make: **\* [all] Error 2
