### PR TITLE
Fix minor typos in Spondoolies SP10 and SP30 drivers

### DIFF
--- a/driver-spondoolies-sp10.c
+++ b/driver-spondoolies-sp10.c
@@ -185,9 +185,9 @@ static struct api_data *spondoolies_api_stats(struct cgpu_info *cgpu)
 	struct api_data *root = NULL;
 
 	root = api_add_int(root, "ASICs total rate", &a->temp_rate, false);
-	root = api_add_int(root, "Temparature front", &a->front_temp, false);
-	root = api_add_int(root, "Temparature rear top", &a->rear_temp_top, false);
-	root = api_add_int(root, "Temparature rear bot", &a->rear_temp_bot, false);
+	root = api_add_int(root, "Temperature front", &a->front_temp, false);
+	root = api_add_int(root, "Temperature rear top", &a->rear_temp_top, false);
+	root = api_add_int(root, "Temperature rear bot", &a->rear_temp_bot, false);
 
 	return root;
 }

--- a/driver-spondoolies-sp30.c
+++ b/driver-spondoolies-sp30.c
@@ -189,9 +189,9 @@ static struct api_data *spondoolies_api_stats_sp30(struct cgpu_info *cgpu)
 	struct api_data *root = NULL;
 
 	root = api_add_int(root, "ASICs total rate", &a->temp_rate, false);
-	root = api_add_int(root, "Temparature front", &a->front_temp, false);
-	root = api_add_int(root, "Temparature rear top", &a->rear_temp_top, false);
-	root = api_add_int(root, "Temparature rear bot", &a->rear_temp_bot, false);
+	root = api_add_int(root, "Temperature front", &a->front_temp, false);
+	root = api_add_int(root, "Temperature rear top", &a->rear_temp_top, false);
+	root = api_add_int(root, "Temperature rear bot", &a->rear_temp_bot, false);
 
   
 


### PR DESCRIPTION
The Spondoolies-Tech drivers have a minor misspelling (API stats, specifically).

Quick question: Is there a convention for casing in the JSON keys? I notice `Studly Caps` is used throughout the base API whereas some of the drivers don't.

cc: @zvisha
