### PR TITLE
Added syslog mask to limit amount of output

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -9581,6 +9581,13 @@ int main(int argc, char *argv[])
 	if (want_per_device_stats)
 		opt_log_output = true;
 
+#ifdef HAVE_SYSLOG_H
+	if (opt_log_output)
+		setlogmask(LOG_UPTO(LOG_DEBUG));
+	else
+		setlogmask(LOG_UPTO(LOG_NOTICE));
+#endif
+
 	if (opt_scantime < 0)
 		opt_scantime = 60;
 


### PR DESCRIPTION
I'm routing output over to syslog. All severities get logged (including INFO), which causes
a zillion lines like this one:
Apr 19 06:25:11 system cgminer[32307]: LIR 0: Share above target
With this change, (unless --verbose is given), the maximum severity is NOTICE and that's
just about what is listed in a NCURSES session.