### PR TITLE
Set request ID in validateaddress JSON-RPC request.

### DIFF
--- a/cgminer.c
+++ b/cgminer.c
@@ -6566,7 +6566,7 @@ static bool setup_gbt_solo(CURL *curl, struct pool *pool)
 		       pool->rpc_url);
 		goto out;
 	}
-	snprintf(s, 256, "{\"method\": \"validateaddress\", \"params\": [\"%s\"]}\n", opt_btc_address);
+	snprintf(s, 256, "{\"id\": 1, \"method\": \"validateaddress\", \"params\": [\"%s\"]}\n", opt_btc_address);
 	val = json_rpc_call(curl, pool->rpc_url, pool->rpc_userpass, s, true,
 			    false, &rolltime, pool, false);
 	if (!val)


### PR DESCRIPTION
The JSON-RPC 1.0 spec (http://json-rpc.org/wiki/specification) states
that requests must include method, params, and id.  The validateaddress
JSON-RPC request was missing the id property, so per the specification,
the node was handling the request as a notification (section 1.3)
instead.

This fixes mining with btcd (https://github.com/btcsuite/btcd).
