### PR TITLE
systemd watchdog and status notification

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ bin_PROGRAMS	= cgminer
 cgminer_LDFLAGS	= $(PTHREAD_FLAGS)
 cgminer_LDADD	= $(DLOPEN_FLAGS) @LIBCURL_LIBS@ @JANSSON_LIBS@ @PTHREAD_LIBS@ \
 		  @NCURSES_LIBS@ @PDCURSES_LIBS@ @WS2_LIBS@ \
-		  @LIBUSB_LIBS@ @MM_LIBS@ @RT_LIBS@ \
+		  @LIBUSB_LIBS@ @MM_LIBS@ @RT_LIBS@ @LIBSYSTEMD_LIBS@ \
 		  @MATH_LIBS@ lib/libgnu.a ccan/libccan.a
 
 cgminer_CPPFLAGS += -I$(top_builddir)/lib -I$(top_srcdir)/lib

--- a/README
+++ b/README
@@ -146,6 +146,8 @@ CGMiner specific configuration options:
                           disabled)
   --disable-libcurl       Disable building with libcurl for getwork and GBT
                           support
+  --enable-libsystemd     Compile support for system watchdog and status
+                          notifications (default disabled)
   --without-curses        Compile support for curses TUI (default enabled)
   --with-system-libusb    Compile against dynamic system libusb (default use
                           included static libusb)

--- a/cgminer.c
+++ b/cgminer.c
@@ -442,7 +442,7 @@ static int include_count;
 	static int forkpid;
 #endif // defined(unix)
 
-struct sigaction termhandler, inthandler;
+struct sigaction termhandler, inthandler, abrthandler;
 
 struct thread_q *getq;
 
@@ -4021,6 +4021,7 @@ static void sighandler(int __maybe_unused sig)
 	/* Restore signal handlers so we can still quit if kill_work fails */
 	sigaction(SIGTERM, &termhandler, NULL);
 	sigaction(SIGINT, &inthandler, NULL);
+	sigaction(SIGABRT, &abrthandler, NULL);
 	kill_work();
 }
 
@@ -9488,6 +9489,7 @@ int main(int argc, char *argv[])
 	sigemptyset(&handler.sa_mask);
 	sigaction(SIGTERM, &handler, &termhandler);
 	sigaction(SIGINT, &handler, &inthandler);
+	sigaction(SIGABRT, &handler, &abrthandler);
 #ifndef WIN32
 	signal(SIGPIPE, SIG_IGN);
 #else

--- a/cgminer.c
+++ b/cgminer.c
@@ -33,6 +33,10 @@
 #include <semaphore.h>
 #endif
 
+#ifdef USE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 #include <sys/stat.h>
 #include <sys/types.h>
 

--- a/configure.ac
+++ b/configure.ac
@@ -566,6 +566,23 @@ else
 fi
 AC_SUBST(LIBCURL_LIBS)
 
+libsystemd="no"
+
+AC_ARG_ENABLE([libsystemd],
+	[AC_HELP_STRING([--enable-libsystemd],[Enable building with libsystemd for watchdog and status notification support])],
+	[libsystemd=$enableval]
+)
+
+if test "x$libsystemd" != xno; then
+	if test "x$have_linux" != xtrue; then
+		AC_MSG_ERROR([libsystemd is only supported on Linux platforms])
+	fi
+
+	PKG_CHECK_MODULES(LIBSYSTEMD, libsystemd, , AC_MSG_ERROR(Could not find libsystemd dev))
+	AC_DEFINE([USE_LIBSYSTEMD], [1], [Defined to 1 if libsystemd support is wanted])
+else
+	LIBSYSTEMD_LIBS=""
+fi
 
 #check execv signature
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([
@@ -648,6 +665,12 @@ if test "x$libcurl" != xno; then
 	echo "  libcurl(GBT+getwork).: Enabled: $LIBCURL_LIBS"
 else
 	echo "  libcurl(GBT+getwork).: Disabled"
+fi
+
+if test "x$libsystemd" != xno; then
+	echo "  libsystemd...........: Enabled: $LIBSYSTEMD_LIBS"
+else
+	echo "  libsystemd...........: Disabled"
 fi
 
 echo "  curses.TUI...........: $cursesmsg"
@@ -808,7 +831,7 @@ echo "Compilation............: make (or gmake)"
 echo "  CPPFLAGS.............: $CPPFLAGS"
 echo "  CFLAGS...............: $CFLAGS"
 echo "  LDFLAGS..............: $LDFLAGS $PTHREAD_FLAGS"
-echo "  LDADD................: $DLOPEN_FLAGS $LIBCURL_LIBS $JANSSON_LIBS $PTHREAD_LIBS $NCURSES_LIBS $PDCURSES_LIBS $WS2_LIBS $MATH_LIBS $LIBUSB_LIBS $RT_LIBS"
+echo "  LDADD................: $DLOPEN_FLAGS $LIBCURL_LIBS $LIBSYSTEMD_LIBS $JANSSON_LIBS $PTHREAD_LIBS $NCURSES_LIBS $PDCURSES_LIBS $WS2_LIBS $MATH_LIBS $LIBUSB_LIBS $RT_LIBS"
 echo
 echo "Installation...........: make install (as root if needed, with 'su' or 'sudo')"
 echo "  prefix...............: $prefix"


### PR DESCRIPTION
More Linux distributions are adopting systemd as their init system. It makes sense to add optional support for it with the benefit of letting users manage cgminer consistently with the other services and tools their distro offers.

This pull request adds a new configure option: `--enable-libsystemd` (disabled by default). When activated, cgminer is built with systemd support for the following features:

* Supervision through [systemd's watchdog](http://0pointer.de/blog/projects/watchdog.html) (through both hardware and software)
* Reporting cgminer's status for easy viewing through `systemctl status`.

A service unit would look similar to the following:

```desktop
[Unit]
Description=CGMiner ASIC/FPGA bitcoin miner
Wants=network-online.target
After=network-online.target

[Service]
Type=notify
ExecStart=/usr/bin/cgminer --text-only --syslog --config /etc/cgminer.conf
StandardOutput=null
StandardError=null
WatchdogSec=1min
Restart=always
RestartSec=0
```

When active, `systemctl status cgminer` might look something like the following:

```
● cgminer.service - CGMiner ASIC/FPGA bitcoin miner
   Loaded: loaded (/usr/lib/systemd/system/cgminer.service; static; vendor preset: enabled)
   Active: active (running) since Sat 2015-05-02 02:11:41 UTC; 1min 16s ago
 Main PID: 554 (cgminer)
   Status: "(5s):2.001T (1m):1.255T (5m):378.3G (15m):136.2G (avg):1.737Th/s"
   CGroup: /system.slice/cgminer.service
           └─554 /usr/bin/cgminer --text-only --syslog --config /etc/cgminer.conf

May 02 02:12:41 my-miner cgminer[554]: Submitting share 000f3dcd to pool 0
May 02 02:12:41 my-miner cgminer[554]: Accepted 0f3dcd2f Diff 4.3K/4096 S30 0
May 02 02:12:55 my-miner cgminer[554]: Submitting share 000c605b to pool 0
May 02 02:12:55 my-miner cgminer[554]: Accepted 0c605b84 Diff 5.29K/4096 S30 0
```