### PR TITLE
store the next difficulty

### DIFF
--- a/miner.h
+++ b/miner.h
@@ -1338,6 +1338,7 @@ struct pool {
 	char bbversion[12];
 	char nbit[12];
 	char ntime[12];
+	double next_diff;
 	double sdiff;
 
 	struct timeval tv_lastwork;

--- a/util.c
+++ b/util.c
@@ -2008,6 +2008,7 @@ static bool parse_notify(struct pool *pool, json_t *val)
 	snprintf(pool->nbit, 9, "%s", nbit);
 	snprintf(pool->ntime, 9, "%s", ntime);
 	pool->swork.clean = clean;
+	pool->sdiff = pool->next_diff;
 	alloc_len = pool->coinbase_len = cb1_len + pool->n1_len + pool->n2size + cb2_len;
 	pool->nonce2_offset = cb1_len + pool->n1_len;
 
@@ -2116,8 +2117,8 @@ static bool parse_diff(struct pool *pool, json_t *val)
 		return false;
 
 	cg_wlock(&pool->data_lock);
-	old_diff = pool->sdiff;
-	pool->sdiff = diff;
+	old_diff = pool->next_diff;
+	pool->next_diff = diff;
 	cg_wunlock(&pool->data_lock);
 
 	if (old_diff != diff) {
@@ -2915,7 +2916,7 @@ out:
 		if (!pool->stratum_url)
 			pool->stratum_url = pool->sockaddr_url;
 		pool->stratum_active = true;
-		pool->sdiff = 1;
+		pool->next_diff = pool->sdiff = 1;
 		if (opt_protocol) {
 			applog(LOG_DEBUG, "Pool %d confirmed mining.subscribe with extranonce1 %s extran2size %d",
 			       pool->pool_no, pool->nonce1, pool->n2size);


### PR DESCRIPTION
Miner should use diff set with set_difficulty for every *NEXT job*. Correct?

Looks like cgminer 4.9.0 uses new diff before next job arrives. Here is an example of network output that we have gathered.

```
[06/17/2015 18:21:03] - Received from pool: {"id":null,"method":"mining.set_extranonce","params":["fb91949075", 7]}
[06/17/2015 18:21:03] - Sending to miner: {"id":null,"method":"mining.set_extranonce","params":["fb91949075", 7]}
...
*[06/17/2015 18:22:33] - Received from pool: {"id":null,"method":"mining.set_difficulty","params":[4096]}
*[06/17/2015 18:22:33] - Sending to miner: {"id":null,"method":"mining.set_difficulty","params":[4096]}
...
[06/17/2015 18:24:10] - Received from pool: {"params":["00000000052f1486", "4ef4a7b5534a292cb1756abf6a08f2bb933abec406235c640000000000000000", .... , "00000003", "18162043", "55820197", false],"id":null,"method":"mining.notify"}
[06/17/2015 18:24:10] - Sending to miner: {"params":["00000000052f1486", "4ef4a7b5534a292cb1756abf6a08f2bb933abec406235c640000000000000000", .... , "00000003", "18162043", "55820197", false],"id":null,"method":"mining.notify"}
...
[06/17/2015 18:24:19] - Received from miner: {"params": ["1DSnPFz1xoHgNSJa1P995Yp9kYL23TXH66.S5203", "00000000052f1486", "19e30300000000", "55820197", "4e51cf38"], "id": 1318, "method": "mining.submit"}
[06/17/2015 18:24:19] - Sending to pool: {"params": ["1DSnPFz1xoHgNSJa1P995Yp9kYL23TXH66.S5203", "00000000052f1486", "19e30300000000", "55820197", "4e51cf38"], "id": 1318, "method": "mining.submit"}
[06/17/2015 18:24:19] - Received from pool: {"id":1318,"result":true,"error":null}
[06/17/2015 18:24:19] - Sending to miner: {"id":1318,"result":true,"error":null}
[06/17/2015 18:24:23] - Received from miner: {"params": ["1DSnPFz1xoHgNSJa1P995Yp9kYL23TXH66.S5203", "00000000052f1486", "fff70300000000", "55820197", "ac350e99"], "id": 1319, "method": "mining.submit"}
[06/17/2015 18:24:23] - Sending to pool: {"params": ["1DSnPFz1xoHgNSJa1P995Yp9kYL23TXH66.S5203", "00000000052f1486", "fff70300000000", "55820197", "ac350e99"], "id": 1319, "method": "mining.submit"}
[06/17/2015 18:24:23] - Received from pool: {"id":1319,"result":true,"error":null}
[06/17/2015 18:24:23] - Sending to miner: {"id":1319,"result":true,"error":null}
*[06/17/2015 18:24:23] - Received from pool: {"id":null,"method":"mining.set_difficulty","params":[2048]}
*[06/17/2015 18:24:23] - Sending to miner: {"id":null,"method":"mining.set_difficulty","params":[2048]}
[06/17/2015 18:24:25] - Received from miner: {"params": ["1DSnPFz1xoHgNSJa1P995Yp9kYL23TXH66.S5203", "00000000052f1486", "42050400000000", "55820197", "66fde833"], "id": 1320, "method": "mining.submit"}
[06/17/2015 18:24:25] - Sending to pool: {"params": ["1DSnPFz1xoHgNSJa1P995Yp9kYL23TXH66.S5203", "00000000052f1486", "42050400000000", "55820197", "66fde833"], "id": 1320, "method": "mining.submit"}
[06/17/2015 18:24:25] - Received from pool: {"id":1320,"result":true,"error":null}
[06/17/2015 18:24:25] - Sending to miner: {"id":1320,"result":true,"error":null}
[06/17/2015 18:24:27] - Received from miner: {"params": ["1DSnPFz1xoHgNSJa1P995Yp9kYL23TXH66.S5203", "00000000052f1486", "7a0d0400000000", "55820197", "b1324660"], "id": 1321, "method": "mining.submit"}
[06/17/2015 18:24:27] - Sending to pool: {"params": ["1DSnPFz1xoHgNSJa1P995Yp9kYL23TXH66.S5203", "00000000052f1486", "7a0d0400000000", "55820197", "b1324660"], "id": 1321, "method": "mining.submit"}
[06/17/2015 18:24:27] - Received from pool: {"id":1321,"result":true,"error":null}
[06/17/2015 18:24:27] - Sending to miner: {"id":1321,"result":true,"error":null}
[06/17/2015 18:24:35] - Received from miner: {"params": ["1DSnPFz1xoHgNSJa1P995Yp9kYL23TXH66.S5203", "00000000052f1486", "81350400000000", "55820197", "82297242"], "id": 1322, "method": "mining.submit"}
[06/17/2015 18:24:35] - Sending to pool: {"params": ["1DSnPFz1xoHgNSJa1P995Yp9kYL23TXH66.S5203", "00000000052f1486", "81350400000000", "55820197", "82297242"], "id": 1322, "method": "mining.submit"}
*[06/17/2015 18:24:35] - Received from pool: {"id":1322,"result":false,"error":[23, "Share above target.", null]}
*[06/17/2015 18:24:35] - Sending to miner: {"id":1322,"result":false,"error":[23, "Share above target.", null]}
```

The last share marked in bold has difficulty of 3798, which is higher than 2048 (latest reported diff), but lower than 4096 (diff of job '00000000052f1486'). As a result, such share is discarded by the pool with reason share above target, because diff of job '00000000052f1486' is 4096 and not 2048.

This problem is not critical in scenario above, because it does not reduce miners hashrate, but if the vice verse happens (change from low to high diff), miner may miss to send some shares which results in slightly reduced hashrate on pool side.

This commit fixes this issue, please review it.