### PR TITLE
Detect and api update for Avalon7

### DIFF
--- a/ASIC-README
+++ b/ASIC-README
@@ -282,6 +282,8 @@ ASIC SPECIFIC COMMANDS
 --avalon4-least-pll <arg> Set least pll check threshold for smart speed mode 2 (default: 768)
 --avalon4-most-pll <arg> Set most pll check threshold for smart speed mode 2 (default: 256)
 --avalon7-voltage   Set Avalon7 default core voltage, in millivolts, step: 78
+--avalon7-voltage-level Set Avalon7 default level of core voltage, range:[0, 15], step: 1
+--avalon7-voltage-offset Set Avalon7 default offset of core voltage, range:[-2, 1], step: 1
 --avalon7-freq      Set Avalon7 default frequency, range:[24, 1404], step: 12, example: 500
 --avalon7-freq-sel <arg> Set Avalon7 default frequency select, range:[0, 5], step: 1, example: 3 (default: 0)
 --avalon7-fan       Set Avalon7 target fan speed, range:[0, 100], step: 1, example: 0-100
@@ -604,6 +606,8 @@ Avalon4 Devices
 Avalon7 Devices
 
 --avalon7-voltage   Set Avalon7 default core voltage, in millivolts, step: 78
+--avalon7-voltage-level Set Avalon7 default level of core voltage, range:[0, 15], step: 1
+--avalon7-voltage-offset Set Avalon7 default offset of core voltage, range:[-2, 1], step: 1
 --avalon7-freq      Set Avalon7 default frequency, range:[24, 1404], step: 12, example: 500
 --avalon7-freq-sel <arg> Set Avalon7 default frequency select, range:[0, 5], step: 1, example: 3 (default: 0)
 --avalon7-fan       Set Avalon7 target fan speed, range:[0, 100], step: 1, example: 0-100

--- a/README
+++ b/README
@@ -231,6 +231,8 @@ Options for both config file and command line:
 --avalon4-least-pll <arg> Set least pll check threshold for smart speed mode 2 (default: 768)
 --avalon4-most-pll <arg> Set most pll check threshold for smart speed mode 2 (default: 256)
 --avalon7-voltage   Set Avalon7 default core voltage, in millivolts, step: 78
+--avalon7-voltage-level Set Avalon7 default level of core voltage, range:[0, 15], step: 1
+--avalon7-voltage-offset Set Avalon7 default offset of core voltage, range:[-2, 1], step: 1
 --avalon7-freq      Set Avalon7 default frequency, range:[24, 1404], step: 12, example: 500
 --avalon7-freq-sel <arg> Set Avalon7 default frequency select, range:[0, 5], step: 1, example: 3 (default: 0)
 --avalon7-fan       Set Avalon7 target fan speed, range:[0, 100], step: 1, example: 0-100
@@ -391,6 +393,8 @@ ASIC only options:
 --avalon4-aucspeed <arg> Set Avalon4 AUC IIC bus speed (default: 400000)
 --avalon4-aucxdelay <arg> Set Avalon4 AUC IIC xfer read delay, 4800 ~= 1ms (default: 9600)
 --avalon7-voltage   Set Avalon7 default core voltage, in millivolts, step: 78
+--avalon7-voltage-level Set Avalon7 default level of core voltage, range:[0, 15], step: 1
+--avalon7-voltage-offset Set Avalon7 default offset of core voltage, range:[-2, 1], step: 1
 --avalon7-freq      Set Avalon7 default frequency, range:[24, 1404], step: 12, example: 500
 --avalon7-freq-sel <arg> Set Avalon7 default frequency select, range:[0, 5], step: 1, example: 3 (default: 0)
 --avalon7-fan       Set Avalon7 target fan speed, range:[0, 100], step: 1, example: 0-100

--- a/cgminer.c
+++ b/cgminer.c
@@ -255,6 +255,8 @@ static char *opt_set_avalon4_freq;
 #ifdef USE_AVALON7
 static char *opt_set_avalon7_fan;
 static char *opt_set_avalon7_voltage;
+static char *opt_set_avalon7_voltage_level;
+static char *opt_set_avalon7_voltage_offset;
 static char *opt_set_avalon7_freq;
 #endif
 #ifdef USE_AVALON_MINER
@@ -1390,6 +1392,12 @@ static struct opt_table opt_config_table[] = {
 	OPT_WITH_CBARG("--avalon7-voltage",
 		     set_avalon7_voltage, NULL, &opt_set_avalon7_voltage,
 		     "Set Avalon7 default core voltage, in millivolts, step: 78"),
+	OPT_WITH_CBARG("--avalon7-voltage-level",
+		     set_avalon7_voltage_level, NULL, &opt_set_avalon7_voltage_level,
+		     "Set Avalon7 default level of core voltage, range:[0, 15], step: 1"),
+	OPT_WITH_CBARG("--avalon7-voltage-offset",
+		     set_avalon7_voltage_offset, NULL, &opt_set_avalon7_voltage_offset,
+		     "Set Avalon7 default offset of core voltage, range:[-2, 1], step: 1"),
 	OPT_WITH_CBARG("--avalon7-freq",
 		     set_avalon7_freq, NULL, &opt_set_avalon7_freq,
 		     "Set Avalon7 default frequency, range:[24, 1404], step: 12, example: 500"),

--- a/driver-avalon7.c
+++ b/driver-avalon7.c
@@ -383,7 +383,7 @@ static inline int get_temp_max(struct avalon7_info *info, int addr)
 	int i;
 	int max = -273;
 
-	for (i = 0; i < AVA7_DEFAULT_MINER_CNT; i++) {
+	for (i = 0; i < info->miner_count[addr]; i++) {
 		if (info->temp[addr][i][3] > max)
 			max = info->temp[addr][i][3];
 	}
@@ -1661,7 +1661,7 @@ static void avalon7_set_freq(struct cgpu_info *avalon7, int addr, int miner_id, 
 			miner_id, be32toh(tmp));
 
 	/* Package the data */
-	avalon7_init_pkg(&send_pkg, AVA7_P_SET_PLL, miner_id + 1, AVA7_DEFAULT_MINER_CNT);
+	avalon7_init_pkg(&send_pkg, AVA7_P_SET_PLL, miner_id + 1, info->miner_count[addr]);
 
 	if (addr == AVA7_MODULE_BROADCAST)
 		avalon7_send_bc_pkgs(avalon7, &send_pkg);

--- a/driver-avalon7.c
+++ b/driver-avalon7.c
@@ -2363,6 +2363,7 @@ static struct api_data *avalon7_api_stats(struct cgpu_info *avalon7)
 
 	root = api_add_bool(root, "Connection Overloaded", &info->conn_overloaded, true);
 	root = api_add_int(root, "Voltage Offset", &opt_avalon7_voltage_offset, true);
+	root = api_add_uint32(root, "Nonce Mask", &opt_avalon7_nonce_mask, true);
 
 	return root;
 }

--- a/driver-avalon7.h
+++ b/driver-avalon7.h
@@ -19,10 +19,6 @@
 #define AVA7_TEMP_FREQADJ		104
 #define AVA7_FREQUENCY_MAX	1404
 
-#define AVA7_MM711_ASIC_CNT		18
-#define AVA7_MM721_ASIC_CNT		18
-#define AVA7_MM741_ASIC_CNT		22
-
 #define AVA7_DEFAULT_FAN_MIN		5 /* % */
 #define AVA7_DEFAULT_FAN_MAX		100
 #define AVA7_DEFAULT_FAN_INTERVAL	15 /* Seconds */
@@ -32,8 +28,8 @@
 #define AVA7_DEFAULT_TEMP_HYSTERESIS	5
 
 #define AVA7_DEFAULT_VOLTAGE_MIN	3889
-#define AVA7_DEFAULT_VOLTAGE	4981
 #define AVA7_DEFAULT_VOLTAGE_MAX	5059
+#define AVA7_INVALID_VOLTAGE	0
 
 #define AVA7_DEFAULT_FREQUENCY_MIN	24 /* NOTE: It cann't support 0 */
 #define AVA7_DEFAULT_FREQUENCY_0	600
@@ -137,16 +133,6 @@
 
 #define AVA7_MODULE_BROADCAST	0
 /* End of avalon7 protocol package type */
-
-#define AVA7_MM711_PREFIXSTR	"711"
-#define AVA7_MM721_PREFIXSTR	"721"
-#define AVA7_MM741_PREFIXSTR	"741"
-#define AVA7_MM_VERNULL		"NONE"
-
-#define AVA7_TYPE_MM711		711
-#define AVA7_TYPE_MM721		721
-#define AVA7_TYPE_MM741		741
-#define AVA7_TYPE_NULL		00
 
 #define AVA7_IIC_RESET		0xa0
 #define AVA7_IIC_INIT		0xa1
@@ -283,6 +269,15 @@ struct avalon7_iic_info {
 		uint32_t aucParam[2];
 		uint8_t slave_addr;
 	} iic_param;
+};
+
+struct avalon7_dev_description {
+	uint8_t dev_id_str[8];
+	int mod_type;
+	uint8_t miner_count; /* it should not greater than AVA7_DEFAULT_MINER_CNT */
+	uint8_t asic_count; /* asic count each miner, it should not great than AVA7_DEFAULT_ASIC_MAX */
+	uint16_t vout_adc_ratio;
+	uint32_t set_voltage;
 };
 
 #define AVA7_WRITE_SIZE (sizeof(struct avalon7_pkg))

--- a/driver-avalon7.h
+++ b/driver-avalon7.h
@@ -30,6 +30,14 @@
 #define AVA7_DEFAULT_VOLTAGE_MIN	3889
 #define AVA7_DEFAULT_VOLTAGE_MAX	5059
 #define AVA7_INVALID_VOLTAGE	0
+#define AVA7_DEFAULT_VOLTAGE_STEP	78
+
+#define AVA7_DEFAULT_VOLTAGE_LEVEL_MIN	0
+#define AVA7_DEFAULT_VOLTAGE_LEVEL_MAX	15
+
+#define AVA7_DEFAULT_VOLTAGE_OFFSET_MIN	-2
+#define AVA7_DEFAULT_VOLTAGE_OFFSET	0
+#define AVA7_DEFAULT_VOLTAGE_OFFSET_MAX	1
 
 #define AVA7_DEFAULT_FREQUENCY_MIN	24 /* NOTE: It cann't support 0 */
 #define AVA7_DEFAULT_FREQUENCY_0	600
@@ -289,6 +297,8 @@ struct avalon7_dev_description {
 extern char *set_avalon7_fan(char *arg);
 extern char *set_avalon7_freq(char *arg);
 extern char *set_avalon7_voltage(char *arg);
+extern char *set_avalon7_voltage_level(char *arg);
+extern char *set_avalon7_voltage_offset(char *arg);
 extern int opt_avalon7_temp_target;
 extern int opt_avalon7_polling_delay;
 extern int opt_avalon7_aucspeed;


### PR DESCRIPTION
* Add a device table for Avalon7 (888d056)
  It is easy for us to add new machines. 
* Add new options for Avalon7 (cdd1c72)
   --avalon7-voltage-level and --avalon7-voltage-offset, it is specially for farm users
* Add nonce mask to api for Avalon7 (c5920ed)
  it is just for better debug purpose.