### PR TITLE
fix ser_number for int16

### DIFF
--- a/util.c
+++ b/util.c
@@ -1039,7 +1039,7 @@ int ser_number(unsigned char *s, int32_t val)
 
 	if (val < 128)
 		len = 1;
-	else if (val < 16512)
+	else if (val < 32768)
 		len = 2;
 	else if (val < 2113664)
 		len = 3;


### PR DESCRIPTION
when testing cgminer on new testnet with BIP34 enable on a lower block height it appears the encoding on the blockheight in the coinbase is incorrectly switching to 3 bytes. 