### PR TITLE
Fix BIP34 Serialization

### DIFF
--- a/util.c
+++ b/util.c
@@ -1037,11 +1037,15 @@ int ser_number(unsigned char *s, int32_t val)
 	int32_t *i32 = (int32_t *)&s[1];
 	int len;
 
+	if (val < 17) {
+		s[0] = 0x50 + val;
+		return 1;
+	}
 	if (val < 128)
 		len = 1;
-	else if (val < 16512)
+	else if (val < 32768)
 		len = 2;
-	else if (val < 2113664)
+	else if (val < 8388608)
 		len = 3;
 	else
 		len = 4;


### PR DESCRIPTION
Height uses CScript() encoding [here](https://github.com/bitcoin/bitcoin/blob/fc61c8322bd7288f7546d18ad04c36c345be13cd/src/validation.cpp#L3027). Because of this we have to use [these](https://github.com/bitcoin/bitcoin/blob/fc61c8322bd7288f7546d18ad04c36c345be13cd/src/script/script.h#L53-L70) script opcodes for the first 16 blocks.