### PR TITLE
FreeBSD improvement and compile warning fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ ACLOCAL_AMFLAGS = -I m4
 JANSSON_CPPFLAGS= -I$(top_builddir)/compat/jansson-2.9/src -I$(top_srcdir)/compat/jansson-2.9/src
 
 if WANT_USBUTILS
-USBUTILS_CPPFLAGS = `pkg-config libusb-1.0 --libs --cflags`
+USBUTILS_CPPFLAGS = `pkg-config libusb-1.0 --cflags`
 else
 USBUTILS_CPPFLAGS =
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,10 @@ if test "x$has_winpthread" != xtrue; then
         PTHREAD_LIBS=-lpthread
 fi
 
+# Does the system have a POSIX clock_nanosleep (which can be given a
+# CLOCK_MONOTONIC argument, can I check for that here too)?
+AC_CHECK_FUNCS(clock_nanosleep)
+
 # Drivers that are designed to be run on dedicated hardware should set standalone to yes
 # All drivers should prepend an x to the drivercount
 

--- a/driver-hashfast.c
+++ b/driver-hashfast.c
@@ -716,7 +716,7 @@ static void hfa_check_options(struct hashfast_info *info)
 	if (!opt_hfa_options)
 		return;
 
-	if (!info->op_name)
+	if (info->op_name[0] == '\0')
 		return;
 
 	maxlen = strlen(info->op_name);

--- a/util.c
+++ b/util.c
@@ -40,6 +40,10 @@
 #endif
 #include <sched.h>
 
+#if (defined(__FreeBSD__) || defined(__OpenBSD__))
+# include <pthread_np.h>
+#endif
+
 #include "miner.h"
 #include "elist.h"
 #include "compat.h"
@@ -1444,8 +1448,7 @@ void cgtimer_sub(cgtimer_t *a, cgtimer_t *b, cgtimer_t *res)
 }
 #endif /* WIN32 */
 
-#if defined(CLOCK_MONOTONIC) && !defined(__FreeBSD__) && !defined(__APPLE__) && !defined(WIN32) /* Essentially just linux */
-//#ifdef CLOCK_MONOTONIC /* Essentially just linux */
+#if defined(CLOCK_MONOTONIC) && HAVE_CLOCK_NANOSLEEP /* Mostly just linux */
 void cgtimer_time(cgtimer_t *ts_start)
 {
 	clock_gettime(CLOCK_MONOTONIC, ts_start);


### PR DESCRIPTION
- FreeBSD 11.1 added clock_nanosleep, which is why the `CLOCK_MONOTONIC` block didn't previously work for FreeBSD.  Retune autoconf to look for that call specifically, rather than specifying operating systems manually in util.c
- Include pthread_np.h on FreeBSD and OpenBSD, as that's where the `pthread_set_name_np()` call for them is defined.
- Remove `--libs` from the **libusb** pkg-config call to avoid link arguments getting into compile arguments.
- Fix an error checking for a NULL in an array address, eliminate compile warning.